### PR TITLE
fix items from code review

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,4 +1,4 @@
-name: pep257
+name: black
 
 on:
   push:
@@ -23,8 +23,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pep257
-      - name: Check pep257 conformity
+          pip install black
+      - name: Check black conformity
         run: |
-          pep257 --ignore=D202,D203 pacdef.py test_pacdef.py
+          black --version
+          black --check pacdef.py test_pacdef.py
 

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9" project-jdk-type="Python SDK" />
+  <component name="PythonCompatibilityInspectionAdvertiser">
+    <option name="version" value="3" />
+  </component>
 </project>

--- a/_completion.zsh
+++ b/_completion.zsh
@@ -7,6 +7,7 @@ _pacdef() {
         local -a actions
         actions=(
             'clean:uninstall packages not managed by pacdef'
+            'edit:edit an imported group file'
             'groups:show names of imported groups'
             'import:import a new group file'
             'remove:remove a group file'
@@ -31,6 +32,9 @@ _pacdef() {
 
 
     case $line[1] in
+        edit)
+            _arguments "1:group file:_files -W '$GROUPDIR'"
+        ;;
         import)
             _arguments "*:new group file(s):_files"
         ;;

--- a/pacdef.py
+++ b/pacdef.py
@@ -1,482 +1,776 @@
 #!/usr/bin/python
 
+"""
+Declarative package manager for Arch Linux.
+
+https://github.com/steven-omaha/pacdef
+"""
+
 from __future__ import annotations
 
 import argparse
 import configparser
 import logging
+import os
 import subprocess
 import sys
+from dataclasses import dataclass
 from enum import Enum
 from os import environ
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Callable
 
-COMMENT = '#'
-PARU = Path('/usr/bin/paru')
-VERSION = 'unknown'
+EXIT_SUCCESS = 0
+EXIT_ERROR = 1
+EXIT_INTERRUPT = 130
+
+COMMENT = "#"
+PARU = Path("/usr/bin/paru")
+VERSION = "unknown"
 
 
-def main():
-    setup_logger()
-    pacdef = Pacdef()
+def _main():
+    _setup_logger()
     args = Arguments()
-
-    if args.action == Actions.clean:
-        pacdef.remove_unmanaged_packages()
-    elif args.action == Actions.groups:
-        pacdef.show_groups()
-    elif args.action == Actions.import_:
-        pacdef.import_groups(args)
-    elif args.action == Actions.remove:
-        pacdef.remove_group(args)
-    elif args.action == Actions.search:
-        pacdef.search_package(args)
-    elif args.action == Actions.show:
-        pacdef.show_group(args)
-    elif args.action == Actions.sync:
-        pacdef.install_packages_from_groups()
-    elif args.action == Actions.unmanaged:
-        pacdef.show_unmanaged_packages()
-    elif args.action == Actions.version:
-        show_version()
-    else:
-        logging.error('This should not happen.')
-        sys.exit(1)
+    config = Config()
+    helper = AURHelper.from_config(config)
+    pacdef = Pacdef(args=args, config=config, aur_helper=helper)
+    pacdef.run_action_from_arg()
 
 
-def get_packages_from_group(group: Path) -> list[str]:
-    try:
-        with open(group, 'r') as fd:
-            lines = fd.readlines()
-    except (IOError, FileNotFoundError):
-        logging.error(f'Could not read group file {group.absolute()}')
-        sys.exit(1)
-    packages = []
-    for line in lines:
-        package = get_package_from_line(line)
-        if package is not None:
-            packages.append(package)
-    return packages
-
-
-def get_package_from_line(line: str) -> Optional[str]:
-    before_comment = line.split(COMMENT)[0]
-    package_name = before_comment.strip()
-    if len(package_name) >= 0:
-        return package_name
-    else:
-        return None
-
-
-def remove_repo_prefix_from_packages(pacdef_packages: list[str]) -> list[str]:
-    result = []
-    for package_string in pacdef_packages:
-        package = remove_repo_prefix_from_package(package_string)
-        result.append(package)
-    return result
-
-
-def remove_repo_prefix_from_package(package_string: str) -> str:
-    """
-    Takes a string in the form `repository/package` and returns the package name only. Returns `package_string` if it
-    does not contain a repository prefix.
-    :param package_string: string of a single package, optionally starting with a repository prefix
-    :return: package name
-    """
-    if '/' in package_string:
-        try:
-            repo, package = package_string.split('/')
-        except ValueError:  # too many values to unpack
-            logging.error(f'could not split this line into repo and package:\n{package_string}')
-            sys.exit(1)
-    else:
-        package = package_string
-    return package
-
-
-def calculate_package_diff(
-        system_packages: list[str], pacdef_packages: list[str], keep_prefix: bool = False
-) -> tuple[list[str], list[str]]:
-    """
-    Using a custom repository that contains a different version of a package that is also present in the standard repos
-    requires distinguishing which version we want to install. Adding the repo in front of the package name (like
-    `panthera/zsh-theme-powerlevel10k`) is understood by at least some AUR helpers (paru). If the string contains a
-    slash, we check if the part after the slash is a known package.
+def _calculate_package_diff(
+    system_packages: list[Package], pacdef_packages: list[Package]
+) -> tuple[list[Package], list[Package]]:
+    """Determine difference in packages between system and pacdef.
 
     :param system_packages: list of packages known by the system
     :param pacdef_packages: list of packages known by pacdef, optionally with repository prefix
-    :param keep_prefix: if a repository prefix exists in a pacdef package, keep it (default: False)
     :return: 2-tuple: list of packages exclusively in argument 1, list of packages exclusively in argument 2
     """
-    logging.debug('calculate_package_diff')
-    logging.debug(f'{system_packages=}')
-    logging.debug(f'{pacdef_packages=}')
+    logging.debug("calculate_package_diff")
+    logging.debug(f"{system_packages=}")
+    logging.debug(f"{pacdef_packages=}")
     system_only = []
     pacdef_only = []
-    pacdef_packages_without_prefix = remove_repo_prefix_from_packages(pacdef_packages)
     for package in system_packages:
-        if package not in pacdef_packages_without_prefix:
+        if package not in pacdef_packages:
             system_only.append(package)
-    for package, package_without_prefix in zip(pacdef_packages, pacdef_packages_without_prefix):
-        if package_without_prefix not in system_packages:
-            if keep_prefix:
-                pacdef_only.append(package)
-            else:
-                pacdef_only.append(package_without_prefix)
-    logging.debug(f'{system_only=}')
-    logging.debug(f'{pacdef_only=}')
+    for package in pacdef_packages:
+        if package not in system_packages:
+            pacdef_only.append(package)
+    logging.debug(f"{system_only=}")
+    logging.debug(f"{pacdef_only=}")
     return system_only, pacdef_only
 
 
-def get_path_from_group_name(conf: Config, group_name: str) -> Path:
-    group = conf.groups_path.joinpath(group_name)
-    if not file_exists(group):
-        if group.is_symlink():
-            logging.warning(f'found group {group.absolute()}, but it is a broken symlink')
-        else:
-            raise FileNotFoundError
-    return group
-
-
-def get_user_confirmation() -> None:
-    user_input = input('Continue? [y/N] ').lower()
-    if len(user_input) > 1 or user_input != 'y':
-        sys.exit(0)
+def _get_user_confirmation() -> None:
+    """Ask the user if he wants to continue. Exits if the answer is not `y` or of length zero."""
+    user_input = input("Continue? [Y/n] ").lower()
+    if user_input == "" or user_input == "y":
+        return
+    else:
+        sys.exit(EXIT_SUCCESS)
 
 
 class Arguments:
-    action: Actions
-    files: Optional[list[Path]]
-    groups: Optional[list[str]]
-    package: Optional[str]
+    """Class providing the command line arguments."""
 
-    def __init__(self):
-        args = self._parse_basic_args()
-        self.action = self._parse_action(args)
-        self.files = self._parse_files(args)
-        self.groups = self._parse_groups(args)
-        self.package = self._parse_package(args)
+    def __init__(self, process_args: bool = True):
+        """Setup the argument parser, parse the args, collect the results in attributes."""
+        if process_args:
+            parser = self._setup_parser()
+            args = parser.parse_args()
+            self.action: Action = self._parse_action(args)
+            self.files: Optional[list[Path]] = self._parse_files(args)
+            self.groups: Optional[list[str]] = self._parse_groups(args)
+            self.package: Optional[Package] = self._parse_package(args)
+        else:
+            self.action = None
+            self.files = None
+            self.groups = None
+            self.package = None
 
     @staticmethod
-    def _parse_package(args: argparse.Namespace) -> Optional[str]:
-        if not hasattr(args, 'package'):
+    def _parse_package(args: argparse.Namespace) -> Optional[Package]:
+        if not hasattr(args, "package"):
             return
-        return args.package
+        return Package(args.package)
 
     @staticmethod
-    def _parse_basic_args() -> argparse.Namespace:
-        parser = argparse.ArgumentParser(description='a declarative manager of Arch packages')
-        subparsers = parser.add_subparsers(dest='action', required=True, metavar='<action>')
-        subparsers.add_parser(Actions.clean.value, help='uninstall packages not managed by pacdef')
-        subparsers.add_parser(Actions.groups.value, help='show names of imported groups')
-        parser_import = subparsers.add_parser(Actions.import_.value, help='import a new group file')
-        parser_import.add_argument('file', nargs='+', help='a group file')
-        parser_remove = subparsers.add_parser(Actions.remove.value, help='remove previously imported group')
-        parser_remove.add_argument('group', nargs='+', help='a previously imported group')
-        parser_search = subparsers.add_parser(Actions.search.value, help='show the group containing a package')
-        parser_search.add_argument('package', help='the package to search for')
-        parser_show_group = subparsers.add_parser(Actions.show.value, help='show packages under an imported group')
-        parser_show_group.add_argument('group', nargs='+', help='a previously imported group')
-        subparsers.add_parser(Actions.sync.value, help='install packages from all imported groups')
-        subparsers.add_parser(Actions.unmanaged.value, help='show explicitly installed packages not managed by pacdef')
-        subparsers.add_parser(Actions.version.value, help='show version info')
-        args = parser.parse_args()
-        return args
+    def _setup_parser() -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser(
+            description="a declarative manager of Arch packages"
+        )
+        subparsers = parser.add_subparsers(
+            dest="action", required=True, metavar="<action>"
+        )
+        subparsers.add_parser(
+            Action.clean.value, help="uninstall packages not managed by pacdef"
+        )
+        parser_edit = subparsers.add_parser(
+            Action.edit.value, help="edit one or more existing group files"
+        )
+        parser_edit.add_argument("group", nargs="+", help="a group file")
+        subparsers.add_parser(Action.groups.value, help="show names of imported groups")
+        parser_import = subparsers.add_parser(
+            Action.import_.value, help="import a new group file"
+        )
+        parser_import.add_argument("file", nargs="+", help="a group file")
+        parser_remove = subparsers.add_parser(
+            Action.remove.value, help="remove previously imported group"
+        )
+        parser_remove.add_argument(
+            "group", nargs="+", help="a previously imported group"
+        )
+        parser_search = subparsers.add_parser(
+            Action.search.value, help="show the group containing a package"
+        )
+        parser_search.add_argument("package", help="the package to search for")
+        parser_show_group = subparsers.add_parser(
+            Action.show.value, help="show packages under an imported group"
+        )
+        parser_show_group.add_argument(
+            "group", nargs="+", help="a previously imported group"
+        )
+        subparsers.add_parser(
+            Action.sync.value, help="install packages from all imported groups"
+        )
+        subparsers.add_parser(
+            Action.unmanaged.value,
+            help="show explicitly installed packages not managed by pacdef",
+        )
+        subparsers.add_parser(Action.version.value, help="show version info")
+        return parser
 
     @staticmethod
     def _parse_files(args: argparse.Namespace) -> Optional[list[Path]]:
-        if not hasattr(args, 'file'):
+        if not hasattr(args, "file"):
             return
         files = [Path(f) for f in args.file]
         return files
 
     @staticmethod
-    def _parse_action(args: argparse.Namespace) -> Actions:
-        for _, action in Actions.__members__.items():
+    def _parse_action(args: argparse.Namespace) -> Action:
+        for _, action in Action.__members__.items():
             if action.value == args.action:
                 return action
         else:
-            logging.error('Did not understand what you want me to do')
-            sys.exit(1)
+            logging.error("Did not understand what you want me to do")
+            sys.exit(EXIT_ERROR)
 
     @staticmethod
     def _parse_groups(args: argparse.Namespace) -> Optional[list[str]]:
-        if not hasattr(args, 'group'):
+        if not hasattr(args, "group"):
             return
         return args.group
 
 
-def dir_exists(path: Path) -> bool:
+def _dir_exists(path: Path) -> bool:
     return path.exists() and path.is_dir()
 
 
-def file_exists(path: Path) -> bool:
+def _file_exists(path: Path) -> bool:
     return path.exists() and path.is_file()
 
 
-class Actions(Enum):
-    clean = 'clean'
-    groups = 'groups'
-    import_ = 'import'
-    remove = 'remove'
-    search = 'search'
-    show = 'show'
-    sync = 'sync'
-    unmanaged = 'unmanaged'
-    version = 'version'
+class Action(Enum):
+    """Enum of actions that can be provided as first argument to `pacdef`."""
+
+    clean = "clean"
+    edit = "edit"
+    groups = "groups"
+    import_ = "import"
+    remove = "remove"
+    search = "search"
+    show = "show"
+    sync = "sync"
+    unmanaged = "unmanaged"
+    version = "version"
 
 
 class Config:
-    aur_helper: AURHelper
-    groups_path: Path
+    """Class reading and holding the runtime configuration."""
 
-    def __init__(self):
+    def __init__(
+        self,
+        groups_path: Path = None,
+        aur_helper: Path = None,
+        config_file: Path = None,
+        editor: Path = None,
+    ):
+        """Instantiate using the provided values. If these are None, use the config file / defaults."""
+        # TODO clean this up, split into multiple parts?
         config_base_dir = self._get_xdg_config_home()
+        pacdef_path = config_base_dir.joinpath("pacdef")
+        config_file = config_file or pacdef_path.joinpath("pacdef.conf")
 
-        pacdef_path = config_base_dir.joinpath('pacdef')
-        config_file = pacdef_path.joinpath('pacdef.conf')
-        self.groups_path = pacdef_path.joinpath('groups')
-
-        if not dir_exists(pacdef_path):
+        self._config_file = self._read_config_file(config_file)
+        self.groups_path: Path = groups_path or pacdef_path.joinpath("groups")
+        logging.info(f"{self.groups_path=}")
+        if not _dir_exists(pacdef_path):
             pacdef_path.mkdir(parents=True)
-        if not dir_exists(self.groups_path):
+        if not _dir_exists(self.groups_path):
             self.groups_path.mkdir()
-        if not file_exists(config_file):
+        if not _file_exists(config_file):
             config_file.touch()
 
-        self.aur_helper = self._get_aur_helper(config_file)
-        logging.info(f"{self.groups_path=}")
+        self.aur_helper: Path = aur_helper or self._get_aur_helper()
+        self._editor: Path | None = editor or self._get_editor()
+        logging.info(f"{self.aur_helper=}")
+
+    @property
+    def editor(self) -> Path:
+        """Get the editor. Error out if none is found."""
+        if self._editor is None:
+            msg = (
+                "I do not know which editor to use.\n"
+                "  Either set the environment variables EDITOR or VISUAL, or set\n"
+                "  editor in the [misc] section in pacdef.conf."
+            )
+            logging.error(msg)
+            sys.exit(EXIT_ERROR)
+        return self._editor
 
     @staticmethod
     def _get_xdg_config_home() -> Path:
         try:
-            config_base_dir = Path(environ['XDG_CONFIG_HOME'])
+            config_base_dir = Path(environ["XDG_CONFIG_HOME"])
         except KeyError:
             home = Path.home()
-            config_base_dir = home.joinpath('.config')
-        logging.debug(f'{config_base_dir=}')
+            config_base_dir = home.joinpath(".config")
+        logging.debug(f"{config_base_dir=}")
         return config_base_dir
 
-    @classmethod
-    def _get_aur_helper(cls, config_file: Path) -> AURHelper:
+    @staticmethod
+    def _read_config_file(config_file: Path) -> configparser.ConfigParser:
         config = configparser.ConfigParser()
-
         try:
             config.read(config_file)
         except configparser.ParsingError as e:
-            logging.error(f'Could not parse the config: {e}')
+            logging.error(f"Could not parse the config: {e}")
+        return config
 
+    def _get_value_from_conf(
+        self, section: str, key: str, warn_missing: bool = False
+    ) -> str | None:
         try:
-            path = Path(config['misc']['aur_helper'])
+            result = self._config_file[section][key]
         except KeyError:
-            logging.warning(f'No AUR helper set. Defaulting to {PARU}')
-            path = PARU
-            cls._write_config_stub(config_file)
+            if warn_missing:
+                logging.warning(f"{key} in section [{section}] not set")
+            result = None
+        return result
 
-        aur_helper = AURHelper(path)
-        return aur_helper
+    def _get_editor(self) -> Path | None:
+        editor = self._get_value_from_conf("misc", "editor", False)
+        if editor is not None:
+            return Path(editor)
+        try:
+            editor = os.environ["EDITOR"]
+            return Path(editor)
+        except KeyError:
+            pass
+        try:
+            editor = os.environ["VISUAL"]
+            return Path(editor)
+        except KeyError:
+            pass
+        return None
 
-    @classmethod
-    def _write_config_stub(cls, config_file: Path):
-        logging.info(f'Created config stub under {config_file}')
-        with open(config_file, 'w') as fd:
-            fd.write('[misc]\n')
-            fd.write(f'aur_helper = {PARU}\n')
+    def _get_aur_helper(self) -> Path:
+        aur_helper = self._get_value_from_conf("misc", "aur_helper", True)
+        if aur_helper is None:
+            logging.warning(f"No AUR helper set. Defaulting to {PARU}")
+            return PARU
+        else:
+            return Path(aur_helper)
 
 
 class AURHelper:
-    class _Switches(Enum):
-        install = ['--sync', '--refresh', '--needed']
-        remove = ['--remove', '--recursive']
-        installed_packages = ['--query', '--quiet']
-        explicitly_installed_packages = ['--query', '--quiet', '--explicit']
+    """Abstraction of AUR helpers that act as pacman wrappers."""
 
-    _path: Path
+    class _Switches:
+        """CLI switches for AUR helpers that wrap pacman."""
+
+        install = ["--sync", "--refresh", "--needed"]
+        remove = ["--remove", "--recursive"]
+        installed_packages = ["--query", "--quiet"]
+        explicitly_installed_packages = ["--query", "--quiet", "--explicit"]
 
     def __init__(self, path: Path):
+        """Default constructor for AURHelper.
+
+        If the AUR helper is not found, and error is raised.
+        :param path: path to the AUR helper to use (example: `/usr/bin/paru`).
+        """
         if not path.is_absolute():
-            path = Path('/usr/bin').joinpath(path)
-        if not file_exists(path):
-            raise FileNotFoundError(f'{path} not found.')
+            path = Path("/usr/bin").joinpath(path)
+        if not _file_exists(path):
+            raise FileNotFoundError(f"{path} not found.")
         self._path = path
         logging.info(f"AUR helper: {self._path}")
 
     def _execute(self, command: list[str]) -> None:
+        """Execute an AUR helper command without checking the output.
+
+        :param command: the command to execute, list of strings.
+        """
         try:
             subprocess.call([str(self._path)] + command)
         except FileNotFoundError:
             logging.error(f'Could not start the AUR helper "{self._path}".')
-            sys.exit(1)
+            sys.exit(EXIT_ERROR)
 
-    def _check_output(self, query: list[str]) -> list[str]:
+    def _get_output(self, query: list[str]) -> list[str]:
+        """Forward the query to the AUR helper, return its STDOUT.
+
+        :param query: command arguments as list of strings
+        :return: AUR helper output as list of strings
+        """
         command = [str(self._path)] + query
-        result = subprocess.check_output(command).decode('utf-8')
-        result_list = result.split('\n')[:-1]  # last entry is zero-length
+        result = subprocess.check_output(command).decode("utf-8")
+        result_list = result.split("\n")[:-1]  # last entry is zero-length
         return result_list
 
-    def install(self, packages: list[str]) -> None:
-        command: list[str] = self._Switches.install.value + packages
+    def install(self, packages: list[Package]) -> None:
+        """Install packages in the system.
+
+        :param packages: list of packages to be installed.
+        """
+        packages_str = [str(p) for p in packages]
+        command: list[str] = self._Switches.install + packages_str
         self._execute(command)
 
-    def remove(self, packages: list[str]) -> None:
-        command: list[str] = self._Switches.remove.value + packages
+    def remove(self, packages: list[Package]) -> None:
+        """Remove the packages from the system.
+
+        :param packages: list of packages to be removed.
+        """
+        packages_str = [str(p) for p in packages]
+        command: list[str] = self._Switches.remove + packages_str
         self._execute(command)
 
-    def get_all_installed_packages(self) -> list[str]:
-        return self._check_output(self._Switches.installed_packages.value)
+    def get_all_installed_packages(self) -> list[Package]:
+        """Query the AUR helper for all installed packages.
 
-    def get_explicitly_installed_packages(self) -> list[str]:
-        return self._check_output(self._Switches.explicitly_installed_packages.value)
+        :return: list of `Package`s that are installed.
+        """
+        packages: list[str] = self._get_output(self._Switches.installed_packages)
+        instances = [Package(p) for p in packages]
+        return instances
+
+    def get_explicitly_installed_packages(self) -> list[Package]:
+        """Query the AUR helper for all explicitly installed packages.
+
+        :return: list of `Package`s that were explicitly installed.
+        """
+        packages = self._get_output(self._Switches.explicitly_installed_packages)
+        instances = [Package(p) for p in packages]
+        return instances
+
+    @classmethod
+    def from_config(cls, config: Config) -> AURHelper:
+        """Create an AUR helper instance using `config.aur_helper`.
+
+        :param config: a instance of Config
+        :return: an instance of AURHelper
+        """
+        return cls(path=config.aur_helper)
+
+
+class Group:
+    """Class representing a group file."""
+
+    def __init__(self, packages: list[Package], path: Path):
+        """Default constructor. Consider Group.from_file where applicable."""
+        self.packages = packages
+        self._path: Path = path
+
+    @property
+    def name(self) -> str:
+        """Return the name of the group."""
+        return self._path.name
+
+    def __contains__(self, item: Package):
+        """Check if package exists in group."""
+        return item in self.packages
+
+    def __getitem__(self, item):
+        """Get the package at index `item`."""
+        return self.packages[item]
+
+    def __len__(self):
+        """Get length of packages."""
+        return len(self.packages)
+
+    def __eq__(self, other: Group | str):
+        """Compare with other groups or strings."""
+        if isinstance(other, Group):
+            return self.name == other.name
+        elif isinstance(other, str):
+            return self.name == other
+        else:
+            raise ValueError("Must be compared with Group or string.")
+
+    def __repr__(self):
+        """Representation are the newline-separated names of the packages."""
+        return "\n".join([package.name for package in self.packages])
+
+    @classmethod
+    def from_file(cls, path: Path) -> Group:
+        """Read a group file, return an instance of Group containing the packages.
+
+        :param path: path to group file
+        :return: instance of Group
+        """
+        text = path.read_text()
+        lines = text.split("\n")[:-1]  # last line is empty
+        packages = []
+        for line in lines:
+            package = cls._get_package_from_line(line)
+            if package is not None:
+                packages.append(package)
+        instance = cls(packages, path)
+        return instance
+
+    @staticmethod
+    def _get_package_from_line(line: str) -> Optional[Package]:
+        """Get package from a line of a group file.
+
+        Ignores everything after a `#` character.
+
+        :param line: a single line of a group file
+        :return: instance of Package when string contained a package, otherwise None.
+        """
+        before_comment = line.split(COMMENT)[0]
+        package_name = before_comment.strip()
+        if len(package_name) >= 0:
+            return Package(package_name)
+        else:
+            return None
 
 
 class Pacdef:
-    _conf: Config
+    """Class representing the main routines of pacdef."""
 
-    def __init__(self):
-        self._conf = Config()
+    def __init__(
+        self,
+        args: Arguments = None,
+        config: Config = None,
+        aur_helper: AURHelper = None,
+    ):
+        """Save the provided arguments as attributes, or use defaults when none are provided."""
+        self._conf = config or Config()
+        self._args = args or Arguments()
+        self._aur_helper = aur_helper or AURHelper(PARU)
+        self._groups: list[Group] = self._read_groups()
 
-    def remove_unmanaged_packages(self):
+    def _get_action_map(self) -> dict[Action, Callable]:
+        """Return a dict matching all actions to their corresponding Pacdef methods."""
+        ACTION_MAP = {
+            Action.clean: self._remove_unmanaged_packages,
+            Action.edit: self._edit_group_file,
+            Action.groups: self._list_groups,
+            Action.import_: self._import_groups,
+            Action.remove: self._remove_group,
+            Action.search: self._search_package,
+            Action.show: self._show_group,
+            Action.sync: self._install_packages_from_groups,
+            Action.unmanaged: self._show_unmanaged_packages,
+            Action.version: _show_version,
+        }
+        return ACTION_MAP
+
+    def _edit_group_file(self) -> None:
+        groups = self._get_group_paths_matching_arguments()
+        try:
+            subprocess.run([self._conf.editor, *groups], check=True)
+        except subprocess.CalledProcessError:
+            sys.exit(EXIT_ERROR)
+
+    def run_action_from_arg(self) -> None:
+        """Get the function from the provided action arg, execute the function."""
+        action_map = self._get_action_map()
+        action_fn = action_map[self._args.action]
+        action_fn()
+
+    def _remove_unmanaged_packages(self) -> None:
+        """Remove packages not managed by pacdef.
+
+        Fetches unmanaged packages, then asks the user to confirm removing the packages. Then removes them using
+        the AUR helper.
+        """
         unmanaged_packages = self._get_unmanaged_packages()
         if len(unmanaged_packages) == 0:
-            print('nothing to do')
-            sys.exit(0)
-        print('Would remove the following packages and their dependencies:')
+            print("nothing to do")
+            sys.exit(EXIT_SUCCESS)
+        print("Would remove the following packages and their dependencies:")
         for package in unmanaged_packages:
             print(package)
-        get_user_confirmation()
-        self._conf.aur_helper.remove(unmanaged_packages)
+        _get_user_confirmation()
+        self._aur_helper.remove(unmanaged_packages)
 
-    def show_groups(self):
+    def _list_groups(self):
+        """Print names of the imported groups to STDOUT."""
         groups = self._get_group_names()
         for group in groups:
             print(group)
 
-    def import_groups(self, args: Arguments) -> None:
+    def _import_groups(self) -> None:
         # check if all file-arguments exist before we do anything (be atomic)
-        for f in args.files:
+        for f in self._args.files:
             path = Path(f)
-            if not file_exists(path):
-                logging.error(f'Cannot import {f}. Is it an existing file?')
-                sys.exit(1)
-        for f in args.files:
+            if not _file_exists(path):
+                logging.error(f"Cannot import {f}. Is it an existing file?")
+                sys.exit(EXIT_ERROR)
+        for f in self._args.files:
             path = Path(f)
             link_target = self._conf.groups_path.joinpath(f.name)
-            if file_exists(link_target):
-                logging.warning(f'{f} already exists, skipping')
+            if _file_exists(link_target):
+                logging.warning(f"{f} already exists, skipping")
             else:
                 link_target.symlink_to(path.absolute())
 
-    def remove_group(self, args: Arguments) -> None:
-        found_groups = []
-        for group_name in args.groups:
-            group_file = self._conf.groups_path.joinpath(group_name)
-            if group_file.is_symlink() or file_exists(group_file):
-                found_groups.append(group_file)
-            else:
-                logging.error(f'Did not find the group {group_name}')
-                sys.exit(1)
+    def _remove_group(self) -> None:
+        """Remove the provided groups from the pacdef groups directory.
+
+        More than one group can be provided. This method is atomic: If not all groups are found, none are removed.
+        """
+        found_groups = self._get_group_paths_matching_arguments()
         for path in found_groups:
             path.unlink()
 
-    def search_package(self, args: Arguments):
-        for group in self._conf.groups_path.iterdir():
-            packages = get_packages_from_group(group)
-            if args.package in packages:
+    def _get_group_paths_matching_arguments(self) -> list[Path]:
+        found_groups = []
+        for group_name in self._args.groups:
+            group_file = self._conf.groups_path.joinpath(group_name)
+            if group_file.is_symlink() or _file_exists(group_file):
+                found_groups.append(group_file)
+            else:
+                logging.error(f"Did not find the group {group_name}")
+                sys.exit(EXIT_ERROR)
+        return found_groups
+
+    def _search_package(self):
+        """Show imported group with contains `_args.package`.
+
+        Only one package may be provided in the args. Exits with `EXIT_ERROR` if the package cannot be found.
+        """
+        for group in self._groups:
+            if self._args.package in group:
                 print(group.name)
-                sys.exit(0)
+                sys.exit(EXIT_SUCCESS)
         else:
-            sys.exit(1)
+            sys.exit(EXIT_ERROR)
 
-    def show_group(self, args: Arguments) -> None:
-        groups_to_show = args.groups
-        imported_groups_name = self._get_group_names()
-        for group_name in groups_to_show:
-            if group_name not in imported_groups_name:
-                logging.error(f"I don't know the group {group_name}.")
-                sys.exit(1)
-        for group_name in groups_to_show:
-            group = get_path_from_group_name(self._conf, group_name)
-            packages = get_packages_from_group(group)
-            for package in packages:
-                print(package)
+    def _show_group(self) -> None:
+        """Show all packages required by an imported group.
 
-    def install_packages_from_groups(self) -> None:
+        More than one group may be provided, which prints the contents of all groups in order.
+        """
+        self._verify_argument_groups_exist()  # be atomic (only print stuff if all args exist)
+        for argument_group in self._args.groups:
+            for imported_group in self._groups:
+                if imported_group == argument_group:
+                    print(imported_group)
+
+    def _verify_argument_groups_exist(self):
+        for arg_group in self._args.groups:
+            if arg_group not in self._groups:
+                logging.error(f"I don't know the group {self._args.groups}.")
+                sys.exit(EXIT_ERROR)
+
+    def _install_packages_from_groups(self) -> None:
+        """Install all packages from the imported package groups."""
         to_install = self._calculate_packages_to_install()
         if len(to_install) == 0:
-            print('nothing to do')
-            sys.exit(0)
-        print('Would install the following packages:')
+            print("nothing to do")
+            sys.exit(EXIT_SUCCESS)
+        print("Would install the following packages:")
         for package in to_install:
             print(package)
-        get_user_confirmation()
-        self._conf.aur_helper.install(to_install)
+        _get_user_confirmation()
+        self._aur_helper.install(to_install)
 
-    def show_unmanaged_packages(self) -> None:
+    def _show_unmanaged_packages(self) -> None:
+        """Print unmanaged packages to STDOUT."""
         unmanaged_packages = self._get_unmanaged_packages()
         for package in unmanaged_packages:
             print(package)
 
-    def _calculate_packages_to_install(self) -> list[str]:
+    def _calculate_packages_to_install(self) -> list[Package]:
+        """Determine which packages must be installed to satisfy the dependencies in the group files.
+
+        :return: list of packages that will be installed
+        """
         pacdef_packages = self._get_managed_packages()
-        installed_packages = self._conf.aur_helper.get_all_installed_packages()
-        _, pacdef_only = calculate_package_diff(installed_packages, pacdef_packages, keep_prefix=True)
+        installed_packages = self._aur_helper.get_all_installed_packages()
+        _, pacdef_only = _calculate_package_diff(installed_packages, pacdef_packages)
         return pacdef_only
 
-    def _get_unmanaged_packages(self) -> list[str]:
-        managed_packages = self._get_managed_packages()
-        explicitly_installed_packages = self._conf.aur_helper.get_explicitly_installed_packages()
-        unmanaged_packages, _ = calculate_package_diff(explicitly_installed_packages, managed_packages)
+    def _get_unmanaged_packages(self) -> list[Package]:
+        """Get explicitly installed packages which are not in the imported pacdef groups.
+
+        :return: list of unmanaged packages
+        """
+        managed_packages: list[Package] = self._get_managed_packages()
+        explicitly_installed_packages = (
+            self._aur_helper.get_explicitly_installed_packages()
+        )
+        unmanaged_packages, _ = _calculate_package_diff(
+            explicitly_installed_packages, managed_packages
+        )
         unmanaged_packages.sort()
         return unmanaged_packages
 
-    def _get_managed_packages(self) -> list[str]:
+    def _get_managed_packages(self) -> list[Package]:
+        """Get all packaged that are known to pacdef (i.e. are located in imported group files).
+
+        :return: list of packages
+        """
         packages = []
-        for group in self._conf.groups_path.iterdir():
-            content = get_packages_from_group(group)
-            packages.extend(content)
+        for group in self._groups:
+            packages.extend(group.packages)
         if len(packages) == 0:
-            logging.warning('pacdef does not know any groups. Import one.')
+            logging.warning("pacdef does not know any packages.")
         return packages
 
     def _get_group_names(self) -> list[str]:
-        groups = [group.name for group in self._get_groups()]
-        logging.info(f'{groups=}')
+        """Get list of the names of all imported groups (= list of filenames in the pacdef group directory).
+
+        :return: list of imported group names
+        """
+        groups = [group.name for group in self._groups]
         return groups
 
-    def _get_groups(self) -> list[Path]:
-        groups = [group for group in self._conf.groups_path.iterdir()]
-        groups.sort()
-        for group in groups:
+    def _read_groups(self) -> list[Group]:
+        """Read all imported groups (= list of files in the pacdef group directory).
+
+        :return: list of imported groups
+        """
+        paths = [group for group in self._conf.groups_path.iterdir()]
+        paths.sort()
+        groups = []
+        for path in paths:
+            self._sanity_check_imported_group(path)
+            # noinspection PyBroadException
+            try:
+                groups.append(Group.from_file(path))
+            except Exception:
+                logging.error(f"Could not parse group file {path}.")
+                print(sys.exit(EXIT_ERROR))
+        logging.debug(f"{groups=}")
+        if len(groups) == 0:
+            logging.warning("pacdef does not know any groups. Import one.")
+        return groups
+
+    def _sanity_check_imported_group(self, group: Path) -> None:
+        """Sanity check an imported group file.
+
+        Checks for broken symlinks, directories and actual files (instead of symlinks). Prints a warning if a
+        check fails.
+
+        :param group: path to a group to be imported
+        """
+
+        def check_dir():
             if group.is_dir():
-                logging.warning(f'found directory {group} in {self._conf.groups_path}')
+                logging.warning(f"found directory {group} in {self._conf.groups_path}")
+
+        def check_broken_symlink():
             if group.is_symlink() and not group.exists():
-                logging.warning(f'found group {group}, but it is a broken symlink')
+                logging.warning(f"found group {group}, but it is a broken symlink")
+
+        def check_not_symlink():
             if not group.is_symlink() and group.is_file():
-                logging.warning(f'found group {group}, but it is not a symlink')
-        logging.debug(f'{groups=}')
-        return groups
+                logging.warning(f"found group {group}, but it is not a symlink")
+
+        check_dir()
+        check_broken_symlink()
+        check_not_symlink()
 
 
-def setup_logger():
+@dataclass
+class Package:
+    """Class that represents a single package."""
+
+    def __init__(self, package_string: str):
+        """Initialize an instance by a package string.
+
+        :param package_string: The string describing the package. May contain a repository prefix followed by a `/`.
+                               Examples: `zsh` or `repo/spotify`.
+        """
+        self.name: str
+        self.repo: Optional[str]
+        self.name, self.repo = self._split_into_name_and_repo(package_string)
+
+    def __eq__(self, other: Package | str):
+        """Check if equal to other package by comparing the name only."""
+        if isinstance(other, Package):
+            return self.name == other.name
+        elif isinstance(other, str):
+            return self.name == other
+        else:
+            raise ValueError("Must be compared with Package or string.")
+
+    def __repr__(self):
+        """Print `repo/package` if a repo was provided, otherwise print `package`."""
+        if self.repo is not None:
+            result = f"{self.repo}/{self.name}"
+        else:
+            result = self.name
+        return result
+
+    @staticmethod
+    def _split_into_name_and_repo(package_string: str) -> tuple[str, Optional[str]]:
+        """Take a string in the form `repository/package`, return package and repository.
+
+        Returns `(package_name, None)` if it does not contain a repository prefix.
+        :param package_string: string of a single package, optionally starting with a repository prefix
+        :return: package name, repository
+        """
+        if "/" in package_string:
+            try:
+                repo, name = package_string.split("/")
+            except ValueError:  # too many values to unpack
+                logging.error(
+                    f"could not split this line into repo and package:\n{package_string}"
+                )
+                raise
+        else:
+            repo = None
+            name = package_string
+        return name, repo
+
+
+def _setup_logger() -> None:
+    """Setup the logger.
+
+    When the log level is below WARNING (i.e. INFO or DEBUG), the line number of the logging statement is printed as
+    well.
+    """
     try:
-        level_name = environ['LOGLEVEL']
+        level_name: str = environ["LOGLEVEL"]
     except KeyError:
-        level_name = 'WARNING'
+        level_name = "WARNING"
 
-    level: int = logging.getLevelName(level_name)
+    level: int = logging.getLevelName(level_name.upper())
     if level < logging.WARNING:
-        logging.basicConfig(format='%(levelname)s:%(lineno)d: %(message)s', level=level)
+        logging.basicConfig(format="%(levelname)s:%(lineno)d: %(message)s", level=level)
     else:
-        logging.basicConfig(format='%(levelname)s: %(message)s', level=level)
+        logging.basicConfig(format="%(levelname)s: %(message)s", level=level)
 
 
-def show_version():
-    print(f'pacdef, version: {VERSION}')
+def _show_version() -> None:
+    """Print version information to STDOUT.
+
+    The value of `VERSION` is set during compile time by the PKGBUILD using `build()`.
+    """
+    print(f"pacdef, version: {VERSION}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     try:
-        main()
+        _main()
     except KeyboardInterrupt:
-        sys.exit(130)
+        sys.exit(EXIT_INTERRUPT)

--- a/test_pacdef.py
+++ b/test_pacdef.py
@@ -1,4 +1,3 @@
-import configparser
 import logging
 import subprocess
 from os import environ
@@ -11,141 +10,113 @@ import pytest
 
 import pacdef
 
-PACMAN = Path('/usr/bin/pacman')
+PACMAN = Path("/usr/bin/pacman")
 PACMAN_EXISTS = PACMAN.exists()
 PARU_EXISTS = pacdef.PARU.exists()
-REASON_NOT_ARCH = 'pacman not found. That\'s not an Arch installation.'
-REASON_PARU_MISSING = 'paru not found'
+REASON_NOT_ARCH = "pacman not found. That's not an Arch installation."
+REASON_PARU_MISSING = "paru not found"
 
 
 def test_dir_exists(tmpdir):
     tmpdir = Path(tmpdir)
-    tmpfile = tmpdir.joinpath('tmpfile')
+    tmpfile = tmpdir.joinpath("tmpfile")
     tmpfile.touch()
-    assert not pacdef.dir_exists(tmpfile)
+    assert not pacdef._dir_exists(tmpfile)
     tmpfile.unlink()
-    assert not pacdef.dir_exists(tmpfile)
-    assert pacdef.dir_exists(tmpdir)
+    assert not pacdef._dir_exists(tmpfile)
+    assert pacdef._dir_exists(tmpdir)
 
 
 def test_file_exists(tmpdir):
-    tmpfile = Path(tmpdir).joinpath('tmpfile')
+    tmpfile = Path(tmpdir).joinpath("tmpfile")
     tmpfile.touch()
-    assert pacdef.file_exists(tmpfile)
+    assert pacdef._file_exists(tmpfile)
     tmpfile.unlink()
-    assert not pacdef.file_exists(tmpfile)
+    assert not pacdef._file_exists(tmpfile)
     tmpfile.mkdir()
-    assert not pacdef.file_exists(tmpfile)
+    assert not pacdef._file_exists(tmpfile)
 
 
 class TestConfig:
     @staticmethod
     def test__get_xdg_config_home(tmpdir, monkeypatch):
-        monkeypatch.delenv('XDG_CONFIG_HOME', raising=False)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
         result = pacdef.Config._get_xdg_config_home()
         assert result == Path(f'{environ["HOME"]}/.config')
 
-        monkeypatch.setenv('XDG_CONFIG_HOME', str(tmpdir))
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmpdir))
         result = pacdef.Config._get_xdg_config_home()
         assert result == Path(tmpdir)
 
     @staticmethod
     def test__get_aur_helper(tmpdir):
-        with mock.patch.object(pacdef, 'file_exists', lambda x: x == Path('/usr/bin/paru')):
-            tmpfile = Path(tmpdir).joinpath('tmp.conf')
+        with mock.patch.object(
+            pacdef, "_file_exists", lambda x: x == Path("/usr/bin/paru")
+        ):
+            tmpfile = Path(tmpdir).joinpath("tmp.conf")
 
-            helper = pacdef.Config._get_aur_helper(tmpfile)
-            assert helper._path == pacdef.PARU
+            conf = pacdef.Config(config_file=tmpfile)
+            assert conf.aur_helper == pacdef.PARU
 
-            with open(tmpfile, 'w') as fd:
-                fd.write('some strange content')
-            helper = pacdef.Config._get_aur_helper(tmpfile)
-            assert helper._path == pacdef.PARU
+            with open(tmpfile, "w") as fd:
+                fd.write("some strange content")
+            conf = pacdef.Config(config_file=tmpfile)
+            assert conf.aur_helper == pacdef.PARU
 
-            with open(tmpfile, 'w') as fd:
-                fd.write('[misc]\nsomething')
-            helper = pacdef.Config._get_aur_helper(tmpfile)
-            assert helper._path == pacdef.PARU
+            with open(tmpfile, "w") as fd:
+                fd.write("[misc]\nsomething")
+            conf = pacdef.Config(config_file=tmpfile)
+            assert conf.aur_helper == pacdef.PARU
 
-            with open(tmpfile, 'w') as fd:
-                fd.write('[misc]\naur_helper=something')
-            with pytest.raises(FileNotFoundError):
-                pacdef.Config._get_aur_helper(tmpfile)
+            something = "something"
+            with open(tmpfile, "w") as fd:
+                fd.write(f"[misc]\naur_helper={something}")
+            conf = pacdef.Config(config_file=tmpfile)
+            assert conf.aur_helper == Path(something)
 
-            with open(tmpfile, 'w') as fd:
-                fd.write('[misc]\naur___hELPer=paru')
-            helper = pacdef.Config._get_aur_helper(tmpfile)
-            assert helper._path == pacdef.PARU
+            with open(tmpfile, "w") as fd:
+                fd.write("[misc]\naur___hELPer=paru")
+            conf = pacdef.Config(config_file=tmpfile)
+            assert conf.aur_helper == pacdef.PARU
 
-            with open(tmpfile, 'w') as fd:
-                fd.write('[misc]\naur_helper=paru')
-            helper = pacdef.Config._get_aur_helper(tmpfile)
-            assert helper._path == pacdef.PARU
+            with open(tmpfile, "w") as fd:
+                fd.write("[misc]\naur_helper=paru")
+            conf = pacdef.Config(config_file=tmpfile)
+            assert conf.aur_helper.name == pacdef.PARU.name
 
-            with open(tmpfile, 'w') as fd:
-                fd.write('[misc]\naur_helper=/usr/bin/paru')
-            helper = pacdef.Config._get_aur_helper(tmpfile)
-            assert helper._path == pacdef.PARU
-
-    @staticmethod
-    def test__write_config_stub(tmpdir):
-        tmpfile = Path('/a')
-        with pytest.raises(PermissionError):
-            pacdef.Config._write_config_stub(tmpfile)
-
-        tmpfile = Path(tmpdir).joinpath('pacdef.conf')
-        pacdef.Config._write_config_stub(tmpfile)
-        config = configparser.ConfigParser()
-        config.read(tmpfile)
-        assert config['misc']['aur_helper'] == str(pacdef.PARU)
+            with open(tmpfile, "w") as fd:
+                fd.write("[misc]\naur_helper=/usr/bin/paru")
+            conf = pacdef.Config(config_file=tmpfile)
+            assert conf.aur_helper == pacdef.PARU
 
     @staticmethod
     def test___init__(tmpdir, monkeypatch):
-        monkeypatch.setenv('XDG_CONFIG_HOME', str(tmpdir))
-        groups = Path(tmpdir).joinpath('pacdef/groups')
-        conf_file = Path(tmpdir).joinpath('pacdef/pacdef.conf')
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmpdir))
+        groups = Path(tmpdir).joinpath("pacdef/groups")
+        conf_file = Path(tmpdir).joinpath("pacdef/pacdef.conf")
 
-        with mock.patch.object(pacdef, 'file_exists', lambda x: x == Path('/usr/bin/paru')):
+        with mock.patch.object(
+            pacdef, "_file_exists", lambda x: x == Path("/usr/bin/paru")
+        ):
             config = pacdef.Config()
-        aur_helper = Path('/usr/bin/paru')
+        aur_helper = Path("/usr/bin/paru")
 
         assert config.groups_path == groups
-        assert config.aur_helper._path == aur_helper
+        assert config.aur_helper == aur_helper
         assert conf_file.is_file()
 
 
-@pytest.mark.parametrize('user_input', ['Y', 'y'])
+@pytest.mark.parametrize("user_input", ["Y", "y", ""])
 def test_get_user_confirmation_continue(user_input):
-    with mock.patch.object(builtins, 'input', lambda _: user_input):
-        assert pacdef.get_user_confirmation() is None
+    with mock.patch.object(builtins, "input", lambda _: user_input):
+        assert pacdef._get_user_confirmation() is None
 
 
-@pytest.mark.parametrize('user_input', ['', 'n', 'N', 'asd#!|^l;"f'])
+@pytest.mark.parametrize("user_input", ["n", "N", 'asd#!|^l;"f'])
 def test_get_user_confirmation_exit(user_input):
-    with mock.patch.object(builtins, 'input', lambda _: user_input):
+    with mock.patch.object(builtins, "input", lambda _: user_input):
         with pytest.raises(SystemExit):
-            pacdef.get_user_confirmation()
-
-
-def test_get_path_from_group_name(tmpdir):
-    conf = pacdef.Config.__new__(pacdef.Config)
-    conf.groups_path = Path(tmpdir)
-    exists = Path(conf.groups_path.joinpath('exists'))
-    exists.touch()
-    result = pacdef.get_path_from_group_name(conf, exists.name)
-    assert result == exists
-
-    with pytest.raises(FileNotFoundError):
-        pacdef.get_path_from_group_name(conf, "does not exist")
-
-    symlink = conf.groups_path.joinpath('symlink')
-    symlink.symlink_to(exists)
-    result = pacdef.get_path_from_group_name(conf, symlink.name)
-    assert result == symlink
-
-    exists.unlink()
-    result = pacdef.get_path_from_group_name(conf, symlink.name)
-    assert result == symlink
+            pacdef._get_user_confirmation()
 
 
 class TestAURHelper:
@@ -157,21 +128,21 @@ class TestAURHelper:
         assert instance._path == PACMAN
 
         with pytest.raises(FileNotFoundError):
-            pacdef.AURHelper(Path('does not exist'))
+            pacdef.AURHelper(Path("does not exist"))
 
     def test__execute(self):
         def check_valid(command_run: list[str]):
             assert command_run[0] == str(instance._path)
             assert command_run[1:] == command_given
 
-        command_given: list[str] = ['some', 'command']
+        command_given: list[str] = ["some", "command"]
         instance = object.__new__(pacdef.AURHelper)
         instance._path = pacdef.PARU
-        with mock.patch.object(subprocess, 'call', check_valid):
+        with mock.patch.object(subprocess, "call", check_valid):
             instance._execute(command_given)
 
         instance = object.__new__(pacdef.AURHelper)
-        instance._path = Path('does not exist')
+        instance._path = Path("does not exist")
         with pytest.raises(SystemExit):
             instance._execute(command_given)
 
@@ -199,40 +170,44 @@ class TestAURHelper:
 
     @pytest.mark.skipif(not PARU_EXISTS, reason=REASON_PARU_MISSING)
     @pytest.mark.parametrize(
-        'packages',
+        "packages",
         [
             [],
-            ['neovim'],
-            ['neovim', 'python'],
-            ['neovim', 'repo/python'],
-        ]
+            ["neovim"],
+            ["neovim", "python"],
+            ["neovim", "repo/python"],
+        ],
     )
     def test_install(self, packages):
         def check_valid(_, command):
-            self.check_switches_valid(command, pacdef.AURHelper._Switches.install.value)
-            self.check_switches_before_packages(command, pacdef.AURHelper._Switches.install.value)
+            self.check_switches_valid(command, pacdef.AURHelper._Switches.install)
+            self.check_switches_before_packages(
+                command, pacdef.AURHelper._Switches.install
+            )
             self.check_packages_present(command, packages)
 
-        with mock.patch.object(pacdef.AURHelper, '_execute', check_valid):
+        with mock.patch.object(pacdef.AURHelper, "_execute", check_valid):
             instance = pacdef.AURHelper(pacdef.PARU)
             instance.install(packages)
 
     @pytest.mark.skipif(not PARU_EXISTS, reason=REASON_PARU_MISSING)
     @pytest.mark.parametrize(
-        'packages',
+        "packages",
         [
             [],
-            ['neovim'],
-            ['neovim', 'python'],
-        ]
+            ["neovim"],
+            ["neovim", "python"],
+        ],
     )
     def test_remove(self, packages):
         def check_valid(_, command):
-            self.check_switches_valid(command, pacdef.AURHelper._Switches.remove.value)
-            self.check_switches_before_packages(command, pacdef.AURHelper._Switches.remove.value)
+            self.check_switches_valid(command, pacdef.AURHelper._Switches.remove)
+            self.check_switches_before_packages(
+                command, pacdef.AURHelper._Switches.remove
+            )
             self.check_packages_present(command, packages)
 
-        with mock.patch.object(pacdef.AURHelper, '_execute', check_valid):
+        with mock.patch.object(pacdef.AURHelper, "_execute", check_valid):
             instance = pacdef.AURHelper(pacdef.PARU)
             instance.remove(packages)
 
@@ -240,11 +215,11 @@ class TestAURHelper:
     def test_get_all_installed_packages_arch(self):
         instance = pacdef.AURHelper(PACMAN)  # pacman is good enough for the test case
         result = instance.get_all_installed_packages()
-        assert type(result) == list
+        assert isinstance(result, list)
         assert len(result) > 0
         for item in result:
-            assert type(item) == str
-            assert len(item) > 0
+            assert isinstance(item, pacdef.Package)
+            assert len(item.name) > 0
 
     @pytest.mark.skipif(not PACMAN_EXISTS, reason=REASON_NOT_ARCH)
     def test_get_explicitly_installed_packages_arch(self):
@@ -253,12 +228,14 @@ class TestAURHelper:
         assert type(result) == list
         assert len(result) > 0
         for item in result:
-            assert type(item) == str
-            assert len(item) > 0
+            assert isinstance(item, pacdef.Package)
+            assert len(item.name) > 0
 
 
 class TestPacdef:
-    def _test_basic_printing_function(self, test_method: str, patched_method: str, capsys):
+    def _test_basic_printing_function(
+        self, test_method: str, patched_method: str, capsys
+    ):
         instance = self._get_instance()
         method = instance.__getattribute__(test_method)
         with mock.patch.object(instance, patched_method, lambda: None):
@@ -271,7 +248,7 @@ class TestPacdef:
         assert len(out) == 0
         assert len(err) == 0
 
-        packages = ['base']
+        packages = ["base"]
         with mock.patch.object(instance, patched_method, lambda: packages):
             method()
         out, err = capsys.readouterr()
@@ -279,7 +256,7 @@ class TestPacdef:
             assert package in out
         assert len(err) == 0
 
-        packages = ['base', 'python']
+        packages = ["base", "python"]
         with mock.patch.object(instance, patched_method, lambda: packages):
             method()
         out, err = capsys.readouterr()
@@ -289,87 +266,97 @@ class TestPacdef:
 
     @staticmethod
     def _get_instance(tmpdir: Optional[Path] = None) -> pacdef.Pacdef:
-        instance = object.__new__(pacdef.Pacdef)
-        conf = object.__new__(pacdef.Config)
-        aur_helper = object.__new__(pacdef.AURHelper)
-        conf.aur_helper = aur_helper
-        if tmpdir is not None:
-            conf.groups_path = tmpdir
-        instance._conf = conf
+        conf = pacdef.Config(groups_path=tmpdir)
+        aur_helper = pacdef.AURHelper(pacdef.PARU)
+        args = pacdef.Arguments(process_args=False)
+        instance = pacdef.Pacdef(args=args, aur_helper=aur_helper, config=conf)
         return instance
 
     def test_remove_unmanaged_packages_none(self):
         instance = self._get_instance()
-        with mock.patch.object(instance, '_get_unmanaged_packages', lambda: []):
+        with mock.patch.object(instance, "_get_unmanaged_packages", lambda: []):
             with pytest.raises(SystemExit):
-                instance.remove_unmanaged_packages()
+                instance._remove_unmanaged_packages()
 
-    @pytest.mark.parametrize('packages', [
+    @pytest.mark.parametrize(
+        "packages",
         [
-            ['neovim'],
-            ['neovim', 'python'],
-        ]
-    ])
+            [
+                ["neovim"],
+                ["neovim", "python"],
+            ]
+        ],
+    )
     def test_remove_unmanaged_packages_for_packages(self, packages):
         def check_valid(args: list[str]) -> None:
             for arg in args:
                 assert arg in packages
 
         instance = self._get_instance()
-        with mock.patch.object(instance._conf.aur_helper, 'remove', check_valid):
-            with mock.patch.object(instance, '_get_unmanaged_packages', lambda: packages):
-                with mock.patch.object(pacdef, 'get_user_confirmation', lambda: None):
-                    instance.remove_unmanaged_packages()
+        with mock.patch.object(instance._aur_helper, "remove", check_valid):
+            with mock.patch.object(
+                instance, "_get_unmanaged_packages", lambda: packages
+            ):
+                with mock.patch.object(pacdef, "_get_user_confirmation", lambda: None):
+                    instance._remove_unmanaged_packages()
 
-    def test_show_groups(self, capsys):
-        self._test_basic_printing_function('show_groups', '_get_group_names', capsys)
+    def test_list_groups(self, capsys):
+        self._test_basic_printing_function("_list_groups", "_get_group_names", capsys)
 
     def test_import_groups(self, caplog, tmpdir):
-        def test_nonexistant(args):
+        def test_nonexistant():
             caplog.clear()
             with pytest.raises(SystemExit):
-                instance.import_groups(args)
+                instance._import_groups()
 
-        def test_existing(args):
+        def test_existing():
             caplog.clear()
             count_before = len(list(groupdir.iterdir()))
-            instance.import_groups(args)
+            instance._import_groups()
             assert len(caplog.records) == 0
             count_after = len(list(groupdir.iterdir()))
-            assert count_after == count_before + len(args.files)
+            count_after_expected = count_before + len(instance._args.files)
+            assert count_after == count_after_expected
 
-        def test_already_imported(args):
+        def test_already_imported():
             caplog.clear()
             count_before = len(list(groupdir.iterdir()))
-            instance.import_groups(args)
+            instance._import_groups()
             assert len(caplog.records) == 2
-            for package, record in zip(args.files, caplog.records):
+            for package, record in zip(instance._args.files, caplog.records):
                 assert str(package) in record.message
             count_after = len(list(groupdir.iterdir()))
             assert count_after == count_before
 
+        def get_instance(new_group_files: list[Path]) -> pacdef.Pacdef:
+            conf = pacdef.Config(groups_path=groupdir)
+            aur_helper = pacdef.AURHelper(pacdef.PARU)
+            args = pacdef.Arguments(process_args=False)
+            args.files = new_group_files
+            instance = pacdef.Pacdef(args=args, aur_helper=aur_helper, config=conf)
+            return instance
+
         tmpdir = Path(tmpdir)
-        groupdir = tmpdir.joinpath('groups')
-        workdir = tmpdir.joinpath('work')
+        groupdir = tmpdir.joinpath("groups")
+        workdir = tmpdir.joinpath("work")
         groupdir.mkdir()
         workdir.mkdir()
         caplog.set_level(logging.WARNING)
 
-        new_group_files = [workdir.joinpath(f'new_group_{x}') for x in range(3)]
-        instance = self._get_instance(groupdir)
-        args = object.__new__(pacdef.Arguments)
-        args.files = [new_group_files[0]]
+        new_group_files = [workdir.joinpath(f"new_group_{x}") for x in range(3)]
+        instance = get_instance(new_group_files)
+        test_nonexistant()
 
-        test_nonexistant(args)
         new_group_files[0].touch()
-        test_existing(args)
+        instance = get_instance([new_group_files[0]])
+        test_existing()
 
         for f in new_group_files:
             f.touch()
-        args.files = new_group_files[1:]
-        test_existing(args)
+        instance._args.files = new_group_files[1:]
+        test_existing()
 
-        test_already_imported(args)
+        test_already_imported()
 
     def test_remove_group(self):
         pass  # TODO
@@ -382,17 +369,17 @@ class TestPacdef:
 
     def test_install_packages_from_groups_none(self):
         instance = self._get_instance()
-        with mock.patch.object(instance, '_calculate_packages_to_install', lambda: []):
+        with mock.patch.object(instance, "_calculate_packages_to_install", lambda: []):
             with pytest.raises(SystemExit):
-                instance.install_packages_from_groups()
+                instance._install_packages_from_groups()
 
     @pytest.mark.parametrize(
-        'packages',
+        "packages",
         [
-            ['neovim'],
-            ['neovim', 'python'],
-            ['neovim', 'repo/python'],
-        ]
+            ["neovim"],
+            ["neovim", "python"],
+            ["neovim", "repo/python"],
+        ],
     )
     def test_install_packages_from_groups_for_packages(self, packages):
         def check_valid(args: list[str]) -> None:
@@ -400,103 +387,77 @@ class TestPacdef:
                 assert arg in packages
 
         instance = self._get_instance()
-        with mock.patch.object(instance._conf.aur_helper, 'install', check_valid):
-            with mock.patch.object(instance, '_calculate_packages_to_install', lambda: packages):
-                with mock.patch.object(pacdef, 'get_user_confirmation', lambda: None):
-                    instance.install_packages_from_groups()
+        with mock.patch.object(instance._aur_helper, "install", check_valid):
+            with mock.patch.object(
+                instance, "_calculate_packages_to_install", lambda: packages
+            ):
+                with mock.patch.object(pacdef, "_get_user_confirmation", lambda: None):
+                    instance._install_packages_from_groups()
 
     def test_show_unmanaged_packages(self, capsys):
-        self._test_basic_printing_function('show_unmanaged_packages', '_get_unmanaged_packages', capsys)
+        self._test_basic_printing_function(
+            "_show_unmanaged_packages", "_get_unmanaged_packages", capsys
+        )
 
     @pytest.mark.parametrize(
-        'pacdef_packages, installed_packages, expected_result',
+        "pacdef_packages, installed_packages, expected_result",
         [
-            (['base'], [], ['base']),
-            ([], ['base'], []),
+            (["base"], [], ["base"]),
+            ([], ["base"], []),
             ([], [], []),
-            (['base'], ['base'], []),
-            (['repo/base'], [], ['repo/base']),
-            (['repo/base'], ['base'], []),
-        ]
+            (["base"], ["base"], []),
+            (["repo/base"], [], ["repo/base"]),
+            (["repo/base"], ["base"], []),
+        ],
     )
-    def test__calculate_packages_to_install(self, pacdef_packages, installed_packages, expected_result):
+    def test__calculate_packages_to_install(
+        self, pacdef_packages, installed_packages, expected_result
+    ):
         instance = self._get_instance()
-        with mock.patch.object(instance, '_get_managed_packages', lambda: pacdef_packages):
-            with mock.patch.object(instance._conf.aur_helper, 'get_all_installed_packages', lambda: installed_packages):
+        pp = [pacdef.Package(item) for item in pacdef_packages]
+        ip = [pacdef.Package(item) for item in installed_packages]
+        er = [pacdef.Package(item) for item in expected_result]
+        with mock.patch.object(instance, "_get_managed_packages", lambda: pp):
+            with mock.patch.object(
+                instance._aur_helper,
+                "get_all_installed_packages",
+                lambda: ip,
+            ):
                 result = instance._calculate_packages_to_install()
-                assert result == expected_result
+                assert result == er
 
     @pytest.mark.parametrize(
-        'pacdef_packages, installed_packages, expected_result',
+        "pacdef_packages, installed_packages, expected_result",
         [
-            (['base'], [], []),
-            ([], ['base'], ['base']),
+            (["base"], [], []),
+            ([], ["base"], ["base"]),
             ([], [], []),
-            (['base'], ['base'], []),
-            (['repo/base'], [], []),
-            (['repo/base'], ['base'], []),
-        ]
+            (["base"], ["base"], []),
+            (["repo/base"], [], []),
+            (["repo/base"], ["base"], []),
+        ],
     )
-    def test_get_unmanaged_packages(self, pacdef_packages, installed_packages, expected_result):
+    def test_get_unmanaged_packages(
+        self, pacdef_packages, installed_packages, expected_result
+    ):
         instance = self._get_instance()
-        with mock.patch.object(instance, '_get_managed_packages', lambda: pacdef_packages):
-            with mock.patch.object(instance._conf.aur_helper, 'get_explicitly_installed_packages',
-                                   lambda: installed_packages):
+        pp = [pacdef.Package(item) for item in pacdef_packages]
+        ip = [pacdef.Package(item) for item in installed_packages]
+        er = [pacdef.Package(item) for item in expected_result]
+        with mock.patch.object(instance, "_get_managed_packages", lambda: pp):
+            with mock.patch.object(
+                instance._aur_helper,
+                "get_explicitly_installed_packages",
+                lambda: ip,
+            ):
                 result = instance._get_unmanaged_packages()
-                assert result == expected_result
+                assert result == er
 
     def test__get_managed_packages(self):
         pass  # TODO
 
     def test__get_group_names(self):
         pass  # TODO
-
-    def test__get_groups(self, tmpdir, caplog):
-        tmpdir = Path(tmpdir)
-        instance = self._get_instance()
-        instance._conf.groups_path = tmpdir
-        caplog.set_level(logging.WARNING)
-
-        filenames = ['a', 'b']
-        paths = [tmpdir.joinpath(f) for f in filenames]
-        for path in paths:
-            path.symlink_to('/dev/null')
-        result = instance._get_groups()
-        for path in paths:
-            assert path in result
-            path.unlink()
-
-        directory = tmpdir.joinpath('directory')
-        directory.mkdir()
-        result = instance._get_groups()
-        assert directory in result
-        assert len(caplog.records) == 1
-        record = caplog.records[0]
-        assert record.levelname == 'WARNING'
-        assert 'found directory' in record.message
-        directory.rmdir()
-        caplog.clear()
-
-        tmpfile = tmpdir.joinpath('tmpfile')
-        tmpfile.touch()
-        result = instance._get_groups()
-        assert tmpfile in result
-        assert len(caplog.records) == 1
-        record = caplog.records[0]
-        assert record.levelname == 'WARNING'
-        assert 'it is not a symlink' in record.message
-        tmpfile.unlink()
-        caplog.clear()
-
-        symlink = tmpdir.joinpath('symlink')
-        target = tmpdir.joinpath('target')
-        symlink.symlink_to(target)
-        result = instance._get_groups()
-        assert symlink in result
-        assert len(caplog.records) >= 1
-        record = caplog.records[-1]
-        assert record.levelname == 'WARNING'
-        assert 'it is a broken symlink' in record.message
 
 
 def test_get_packages_from_group():
@@ -516,34 +477,24 @@ def test_remove_repo_prefix_from_package():
 
 
 @pytest.mark.parametrize(
-    'pacdef_packages, system_packages, pacdef_only, system_only',
+    "pacdef_packages, system_packages, pacdef_only, system_only",
     [
-        (['base'], [], ['base'], []),
-        ([], ['base'], [], ['base']),
+        (["base"], [], ["base"], []),
+        ([], ["base"], [], ["base"]),
         ([], [], [], []),
-        (['base'], ['base'], [], []),
-        (['repo/base'], ['base'], [], []),
-        (['repo/base'], [], ['base'], []),
-    ]
+        (["base"], ["base"], [], []),
+        (["repo/base"], ["base"], [], []),
+        (["repo/base"], [], ["base"], []),
+    ],
 )
-def test_calculate_package_diff_keep_prefix_no(pacdef_packages, system_packages, pacdef_only, system_only):
-    system_result, pacdef_result = pacdef.calculate_package_diff(system_packages, pacdef_packages, keep_prefix=False)
-    assert system_result == system_only
-    assert pacdef_result == pacdef_only
+def test_calculate_package_diff(
+    pacdef_packages, system_packages, pacdef_only, system_only
+):
+    def to_package(x: list[str]):
+        return [pacdef.Package(item) for item in x]
 
-
-@pytest.mark.parametrize(
-    'pacdef_packages, system_packages, pacdef_only, system_only',
-    [
-        (['base'], [], ['base'], []),
-        ([], ['base'], [], ['base']),
-        ([], [], [], []),
-        (['base'], ['base'], [], []),
-        (['repo/base'], ['base'], [], []),
-        (['repo/base'], [], ['repo/base'], []),
-    ]
-)
-def test_calculate_package_diff_keep_prefix_yes(pacdef_packages, system_packages, pacdef_only, system_only):
-    system_result, pacdef_result = pacdef.calculate_package_diff(system_packages, pacdef_packages, keep_prefix=True)
-    assert system_result == system_only
-    assert pacdef_result == pacdef_only
+    system_result, pacdef_result = pacdef._calculate_package_diff(
+        to_package(system_packages), to_package(pacdef_packages)
+    )
+    assert system_result == to_package(system_only)
+    assert pacdef_result == to_package(pacdef_only)


### PR DESCRIPTION
* compatiblity check with 3.10
* add: exit code constants
* add: todos from code review
* chg: replace `open` with Pathlib methods
* chg: _Switches is no longer an enum
* chg: public methods now protected
* del: declaration of AURHelper._path
* chg: _check_output --> _get_output
* chg: type hint `_setup_logger`
* chg: `_setup_logger` uses variable in `.upper()`
* chg: `Actions` --> `Action`
* introduced `ACTION_MAP`
* refactored `Arguments`
* chg: `Pacdef` methods use `_args` attribute
* fix: remove empty line when printing file content
* chg: reversed `_get_user_confirmation`
* add: class `Package`
* chg: applied black
* chg: refactor `Pacdef._sanity_check()`
* attempt fixing docstring issue
* add: pep257 docstrings
* add: some more docstrings
* chg: proper exit code if user does not confirm
* add: black.yml workflow
* fix: pep257 violation
* chg: pep257 ignore D202, D203
* add: more docstrings
* chg: tests track new method names
* chg: `Pacdef._sanity_check_imported_group`
* add: badges for pep257, bandit, black
* fix: some broken tests
* fix: remaining tests
* add: todos
* fix: black formatting
* chg: `Package` made dataclass
* fix: pep257 conformity
* chg: `_show_groups` -> `_list_groups`
* add: class `Groups`
* add: more code
* add: `edit` command
* del: TODO
* del: VIM
* fix: confirmation dialog
* del: test for write_config_stub
* fix: test get_user_confirmation
* del: test _get_path_from_group_name
* del: test for _get_groups