### PR TITLE
option to add to rm

### DIFF
--- a/src/pacdef/aur_helper.py
+++ b/src/pacdef/aur_helper.py
@@ -69,7 +69,7 @@ class AURHelper:
         """
         config = Config()
         aur_helper_rm_args: list[str] = config.aur_helper_rm_args or []
-        switches_remove: list[str] = list(set(Switches.remove + aur_helper_rm_args))
+        switches_remove: list[str] = list(Switches.remove + aur_helper_rm_args)
         packages_str = [str(p) for p in packages]
         command: list[str] = switches_remove + packages_str
         self._execute(command)

--- a/src/pacdef/aur_helper.py
+++ b/src/pacdef/aur_helper.py
@@ -67,8 +67,11 @@ class AURHelper:
 
         :param packages: list of packages to be removed.
         """
+        config = Config()
+        aur_helper_rm_args: list[str] = config.aur_helper_rm_args or []
+        switches_remove: list[str] = list(set(Switches.remove + aur_helper_rm_args))
         packages_str = [str(p) for p in packages]
-        command: list[str] = Switches.remove + packages_str
+        command: list[str] = switches_remove + packages_str
         self._execute(command)
 
     @classmethod

--- a/src/pacdef/config.py
+++ b/src/pacdef/config.py
@@ -20,6 +20,7 @@ class Config:
         *,
         groups_path: Optional[Path] = None,
         aur_helper: Optional[Path] = None,
+        aur_helper_rm_args: Optional[list[str]] = None,
         config_file_path: Optional[Path] = None,
         editor: Optional[Path] = None,
         warn_symlinks: bool = True,
@@ -35,6 +36,7 @@ class Config:
         self._create_config_files_and_dirs(config_file_path, pacdef_path)
 
         self.aur_helper: Path = aur_helper or self._get_aur_helper()
+        self.aur_helper_rm_args: list[str] = aur_helper_rm_args or self._get_rm_args()
         self._editor: Path | None = editor or self._get_editor()
         self._warn_symlinks: bool = warn_symlinks and self._get_warn_symlinks()
         logging.info(f"{self.aur_helper=}")
@@ -86,6 +88,13 @@ class Config:
         if editor is not None:
             return Path(editor)
         return None
+
+    def _get_rm_args(self) -> list[str] | None:
+        args = self._get_value_from_conf("misc", "aur_rm_args")
+        if args is not None:
+            return args.split()
+        else:
+            return None
 
     @classmethod
     def _get_value_from_env_variables(

--- a/src/pacdef/config.py
+++ b/src/pacdef/config.py
@@ -36,7 +36,7 @@ class Config:
         self._create_config_files_and_dirs(config_file_path, pacdef_path)
 
         self.aur_helper: Path = aur_helper or self._get_aur_helper()
-        self.aur_helper_rm_args: list[str] = aur_helper_rm_args or self._get_rm_args()
+        self.aur_helper_rm_args: list[str] | None = aur_helper_rm_args or self._get_rm_args()
         self._editor: Path | None = editor or self._get_editor()
         self._warn_symlinks: bool = warn_symlinks and self._get_warn_symlinks()
         logging.info(f"{self.aur_helper=}")
@@ -93,8 +93,6 @@ class Config:
         args = self._get_value_from_conf("misc", "aur_rm_args")
         if args is not None:
             return args.split()
-        else:
-            return None
 
     @classmethod
     def _get_value_from_env_variables(


### PR DESCRIPTION
Add the possibility to specify remove options for AUR helper in the config file.
Example:
```
[misc]
aur_helper = yay
aur_rm_args = --cascade
```
in this example, as a consequence `yay` will remove automatically all the dependencies of the packages when calling `clean`.  This is useful when cleaning a lot of packages and without the cascade you get a lot of error messages saying that you can't uninstall because this would break such and such dependencies.