### PR TITLE
feat(groups): allow nested group dirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "termios",
+ "walkdir",
 ]
 
 [[package]]
@@ -480,6 +481,15 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scratch"
@@ -617,6 +627,16 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "winapi"

--- a/crates/pacdef_core/Cargo.toml
+++ b/crates/pacdef_core/Cargo.toml
@@ -19,6 +19,7 @@ const_format = { version = "0.2", default-features = false }
 path-absolutize = "3.0"
 regex = { version = "1.7", default-features = false, features = ["std"] }
 termios = "0.3"
+walkdir = "2.3"
 
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
Instead of expecting all files to be located immediately under the group dir, we allow them to be nested in additional folders. We walk the group folder, and treat every file as a group file. The relative path of the file as seen from the group dir becomes the group name.

Fixes #27.