### PR TITLE
Added call to create config directory

### DIFF
--- a/crates/main/main.rs
+++ b/crates/main/main.rs
@@ -91,6 +91,8 @@ fn load_default_config(config_file: &Path) -> Result<Config> {
 }
 
 fn create_empty_config_file(config_file: &Path) -> Result<()> {
+    std::fs::create_dir_all(config_file.parent().context("getting parent dir")?)
+        .context("creating parent dir")?;
     std::fs::File::create(config_file).context("creating empty config file")?;
     Ok(())
 }


### PR DESCRIPTION
Hi,

When using pacdef for the first time, I was getting the following error:
```
Error: creating empty config file

Caused by:
    No such file or directory (os error 2)
```

And noticed that the parent directory (~/.config/pacdef) didn't exist upon running and wasn't being created. I made this change to make it work for me, so I may as well open a PR with my changes
If there's a different way you'd prefer to handle this, or if I've missed something, feel free to delete this PR : )

Thanks!