### PR TITLE
feat(fedora): Add fedora as a backend

### DIFF
--- a/crates/pacdef_core/src/backend/actual/fedora.rs
+++ b/crates/pacdef_core/src/backend/actual/fedora.rs
@@ -1,11 +1,12 @@
 use core::panic;
 use std::collections::HashSet;
-use std::process::{Command, ExitStatus};
+use std::process::Command;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 use crate::backend::backend_trait::{Backend, Switches, Text};
 use crate::backend::macros::impl_backend_constants;
+use crate::cmd::run_external_command;
 use crate::{Group, Package};
 
 #[derive(Debug, Clone)]
@@ -57,7 +58,7 @@ impl Backend for Fedora {
     }
 
     /// Install the specified packages.
-    fn install_packages(&self, packages: &[Package], noconfirm: bool) -> Result<ExitStatus> {
+    fn install_packages(&self, packages: &[Package], noconfirm: bool) -> Result<()> {
         let mut cmd = Command::new("sudo");
         cmd.arg(self.get_binary());
         cmd.args(self.get_switches_install());
@@ -70,11 +71,10 @@ impl Backend for Fedora {
             cmd.arg(format!("{p}"));
         }
 
-        cmd.status()
-            .with_context(|| format!("running command {cmd:?}"))
+        run_external_command(cmd)
     }
 
-    fn remove_packages(&self, packages: &[Package], noconfirm: bool) -> Result<ExitStatus> {
+    fn remove_packages(&self, packages: &[Package], noconfirm: bool) -> Result<()> {
         let mut cmd = Command::new("sudo");
         cmd.arg(self.get_binary());
         cmd.args(self.get_switches_remove());
@@ -87,11 +87,10 @@ impl Backend for Fedora {
             cmd.arg(format!("{p}"));
         }
 
-        cmd.status()
-            .with_context(|| format!("running command [{cmd:?}]"))
+        run_external_command(cmd)
     }
 
-    fn make_dependency(&self, _: &[Package]) -> Result<ExitStatus> {
+    fn make_dependency(&self, _: &[Package]) -> Result<()> {
         panic!("Not supported by the package manager!")
     }
 }

--- a/crates/pacdef_core/src/backend/actual/fedora.rs
+++ b/crates/pacdef_core/src/backend/actual/fedora.rs
@@ -18,17 +18,21 @@ const BINARY: Text = "dnf";
 const SECTION: Text = "fedora";
 
 const SWITCHES_INFO: Switches = &[
-    "repoquery",
-    "--installed",
-    "--queryformat",
-    "%{from_repo}/%{name}",
-];
+const SWITCHES_INFO: Switches = &["info"];
 const SWITCHES_INSTALL: Switches = &["install"];
 const SWITCHES_MAKE_DEPENDENCY: Switches = &[];
 const SWITCHES_NOCONFIRM: Switches = &["--assumeyes"];
 const SWITCHES_REMOVE: Switches = &["remove"];
 
+    "repoquery",
+    "--installed",
+    "--queryformat",
+    "%{from_repo}/%{name}",
+];
+
 const SUPPORTS_AS_DEPENDENCY: bool = true;
+/// fill stuff here
+const DEFAULT_REPOS: [&str; 5] = ["koji", "fedora", "updates", "anaconda", "@"];
 
 impl Backend for Fedora {
     impl_backend_constants!();
@@ -38,7 +42,7 @@ impl Backend for Fedora {
         cmd.args(self.get_switches_info());
 
         let output = String::from_utf8(cmd.output()?.stdout)?;
-        let packages: HashSet<Package> = output.lines().map(create_package).collect();
+        let packages = output.lines().map(create_package).collect();
 
         Ok(packages)
     }
@@ -53,7 +57,7 @@ impl Backend for Fedora {
         ]);
 
         let output = String::from_utf8(cmd.output()?.stdout)?;
-        let packages: HashSet<Package> = output.lines().map(create_package).collect();
+        let packages = output.lines().map(create_package).collect();
 
         Ok(packages)
     }
@@ -112,13 +116,7 @@ impl Fedora {
 }
 
 fn create_package(package: &str) -> Package {
-    if (package.contains("koji")
-        || package.contains("fedora")
-        || package.contains("updates")
-        || package.contains("anaconda")
-        || package.contains('@'))
-        && !package.contains("copr")
-    {
+    if DEFAULT_REPOS.iter().any(|repo| package.contains(repo)) && !package.contains("copr") {
         let package = package.split('/').nth(1).expect("Cannot be empty!");
         package.into()
     } else {

--- a/crates/pacdef_core/src/backend/actual/fedora.rs
+++ b/crates/pacdef_core/src/backend/actual/fedora.rs
@@ -38,7 +38,7 @@ impl Backend for Fedora {
         cmd.args(self.get_switches_info());
         let output = String::from_utf8(cmd.output()?.stdout)?;
 
-        let packages: HashSet<Package> = output.lines().map(|package| package.into()).collect();
+        let packages: HashSet<Package> = output.lines().map(create_package).collect();
         Ok(packages)
     }
 
@@ -53,7 +53,7 @@ impl Backend for Fedora {
 
         let output = String::from_utf8(cmd.output()?.stdout)?;
 
-        let packages: HashSet<Package> = output.lines().map(|package| package.into()).collect();
+        let packages: HashSet<Package> = output.lines().map(create_package).collect();
         Ok(packages)
     }
 
@@ -105,5 +105,20 @@ impl Fedora {
         Self {
             packages: HashSet::new(),
         }
+    }
+}
+
+fn create_package(package: &str) -> Package {
+    if (package.contains("koji")
+        || package.contains("fedora")
+        || package.contains("updates")
+        || package.contains("anaconda")
+        || package.contains('@'))
+        && !package.contains("copr")
+    {
+        let package = package.split('/').nth(1).expect("Cannot be empty!");
+        package.into()
+    } else {
+        package.into()
     }
 }

--- a/crates/pacdef_core/src/backend/actual/fedora.rs
+++ b/crates/pacdef_core/src/backend/actual/fedora.rs
@@ -36,9 +36,10 @@ impl Backend for Fedora {
     fn get_all_installed_packages(&self) -> Result<HashSet<Package>> {
         let mut cmd = Command::new(self.get_binary());
         cmd.args(self.get_switches_info());
-        let output = String::from_utf8(cmd.output()?.stdout)?;
 
+        let output = String::from_utf8(cmd.output()?.stdout)?;
         let packages: HashSet<Package> = output.lines().map(create_package).collect();
+
         Ok(packages)
     }
 
@@ -52,8 +53,8 @@ impl Backend for Fedora {
         ]);
 
         let output = String::from_utf8(cmd.output()?.stdout)?;
-
         let packages: HashSet<Package> = output.lines().map(create_package).collect();
+
         Ok(packages)
     }
 
@@ -74,6 +75,7 @@ impl Backend for Fedora {
             }
         }
 
+        // add these two repositories as these are needed for many dependencies
         cmd.args(["--repo", "updates"]);
         cmd.args(["--repo", "fedora"]);
 
@@ -92,6 +94,7 @@ impl Backend for Fedora {
         for p in packages {
             cmd.arg(&p.name);
         }
+
         run_external_command(cmd)
     }
 

--- a/crates/pacdef_core/src/backend/actual/fedora.rs
+++ b/crates/pacdef_core/src/backend/actual/fedora.rs
@@ -17,13 +17,21 @@ pub struct Fedora {
 const BINARY: Text = "dnf";
 const SECTION: Text = "fedora";
 
-const SWITCHES_INFO: Switches = &[
 const SWITCHES_INFO: Switches = &["info"];
 const SWITCHES_INSTALL: Switches = &["install"];
 const SWITCHES_MAKE_DEPENDENCY: Switches = &[];
 const SWITCHES_NOCONFIRM: Switches = &["--assumeyes"];
 const SWITCHES_REMOVE: Switches = &["remove"];
 
+
+const SWITCHES_FETCH_USER: Switches = &[
+    "repoquery",
+    "--userinstalled",
+    "--queryformat",
+    "%{from_repo}/%{name}",
+];
+
+const SWITCHES_FETCH_GLOBAL: Switches = &[
     "repoquery",
     "--installed",
     "--queryformat",
@@ -39,7 +47,7 @@ impl Backend for Fedora {
 
     fn get_all_installed_packages(&self) -> Result<HashSet<Package>> {
         let mut cmd = Command::new(self.get_binary());
-        cmd.args(self.get_switches_info());
+        cmd.args(SWITCHES_FETCH_GLOBAL);
 
         let output = String::from_utf8(cmd.output()?.stdout)?;
         let packages = output.lines().map(create_package).collect();
@@ -49,12 +57,7 @@ impl Backend for Fedora {
 
     fn get_explicitly_installed_packages(&self) -> Result<HashSet<Package>> {
         let mut cmd = Command::new(self.get_binary());
-        cmd.args([
-            "repoquery",
-            "--userinstalled",
-            "--queryformat",
-            "%{from_repo}/%{name}",
-        ]);
+        cmd.args(SWITCHES_FETCH_USER);
 
         let output = String::from_utf8(cmd.output()?.stdout)?;
         let packages = output.lines().map(create_package).collect();

--- a/crates/pacdef_core/src/backend/actual/fedora.rs
+++ b/crates/pacdef_core/src/backend/actual/fedora.rs
@@ -21,7 +21,7 @@ const SWITCHES_INFO: Switches = &[
     "repoquery",
     "--installed",
     "--queryformat",
-    "%{reponame}/%{name}",
+    "%{from_repo}/%{name}",
 ];
 const SWITCHES_INSTALL: Switches = &["install"];
 const SWITCHES_MAKE_DEPENDENCY: Switches = &[];
@@ -48,7 +48,7 @@ impl Backend for Fedora {
             "repoquery",
             "--userinstalled",
             "--queryformat",
-            "%{reponame}/%{name}",
+            "%{from_repo}/%{name}",
         ]);
 
         let output = String::from_utf8(cmd.output()?.stdout)?;
@@ -68,8 +68,14 @@ impl Backend for Fedora {
         }
 
         for p in packages {
-            cmd.arg(format!("{p}"));
+            cmd.arg(&p.name);
+            if let Some(repo) = p.repo.as_ref() {
+                cmd.args(&["--repo", repo]);
+            }
         }
+
+        cmd.args(&["--repo", "updates"]);
+        cmd.args(&["--repo", "fedora"]);
 
         run_external_command(cmd)
     }
@@ -84,9 +90,8 @@ impl Backend for Fedora {
         }
 
         for p in packages {
-            cmd.arg(format!("{p}"));
+            cmd.arg(&p.name);
         }
-
         run_external_command(cmd)
     }
 

--- a/crates/pacdef_core/src/backend/actual/fedora.rs
+++ b/crates/pacdef_core/src/backend/actual/fedora.rs
@@ -25,6 +25,8 @@ const SWITCHES_REMOVE: Switches = &["remove"];
 
 const SUPPORTS_AS_DEPENDENCY: bool = false;
 
+/// These switches are responsible for
+/// getting the packages explicitly installed by the user
 const SWITCHES_FETCH_USER: Switches = &[
     "repoquery",
     "--userinstalled",
@@ -32,6 +34,8 @@ const SWITCHES_FETCH_USER: Switches = &[
     "%{from_repo}/%{name}",
 ];
 
+/// These switches are responsible for
+/// getting all the packages installed on the system
 const SWITCHES_FETCH_GLOBAL: Switches = &[
     "repoquery",
     "--installed",
@@ -39,7 +43,8 @@ const SWITCHES_FETCH_GLOBAL: Switches = &[
     "%{from_repo}/%{name}",
 ];
 
-/// fill stuff here
+/// These repositories are ignored when storing the packages
+/// as these are present by default on any sane fedora system
 const DEFAULT_REPOS: [&str; 5] = ["koji", "fedora", "updates", "anaconda", "@"];
 
 impl Backend for Fedora {
@@ -89,6 +94,7 @@ impl Backend for Fedora {
         run_external_command(cmd)
     }
 
+    /// Show information from package manager for package.
     fn remove_packages(&self, packages: &[Package], noconfirm: bool) -> Result<()> {
         let mut cmd = Command::new("sudo");
         cmd.arg(self.get_binary());

--- a/crates/pacdef_core/src/backend/actual/fedora.rs
+++ b/crates/pacdef_core/src/backend/actual/fedora.rs
@@ -70,12 +70,12 @@ impl Backend for Fedora {
         for p in packages {
             cmd.arg(&p.name);
             if let Some(repo) = p.repo.as_ref() {
-                cmd.args(&["--repo", repo]);
+                cmd.args(["--repo", repo]);
             }
         }
 
-        cmd.args(&["--repo", "updates"]);
-        cmd.args(&["--repo", "fedora"]);
+        cmd.args(["--repo", "updates"]);
+        cmd.args(["--repo", "fedora"]);
 
         run_external_command(cmd)
     }

--- a/crates/pacdef_core/src/backend/actual/fedora.rs
+++ b/crates/pacdef_core/src/backend/actual/fedora.rs
@@ -23,6 +23,7 @@ const SWITCHES_MAKE_DEPENDENCY: Switches = &[];
 const SWITCHES_NOCONFIRM: Switches = &["--assumeyes"];
 const SWITCHES_REMOVE: Switches = &["remove"];
 
+const SUPPORTS_AS_DEPENDENCY: bool = false;
 
 const SWITCHES_FETCH_USER: Switches = &[
     "repoquery",
@@ -38,7 +39,6 @@ const SWITCHES_FETCH_GLOBAL: Switches = &[
     "%{from_repo}/%{name}",
 ];
 
-const SUPPORTS_AS_DEPENDENCY: bool = true;
 /// fill stuff here
 const DEFAULT_REPOS: [&str; 5] = ["koji", "fedora", "updates", "anaconda", "@"];
 
@@ -101,6 +101,14 @@ impl Backend for Fedora {
         for p in packages {
             cmd.arg(&p.name);
         }
+
+        run_external_command(cmd)
+    }
+
+    fn show_package_info(&self, package: &Package) -> Result<()> {
+        let mut cmd = Command::new(self.get_binary());
+        cmd.args(self.get_switches_info());
+        cmd.arg(&package.name);
 
         run_external_command(cmd)
     }

--- a/crates/pacdef_core/src/backend/actual/fedora.rs
+++ b/crates/pacdef_core/src/backend/actual/fedora.rs
@@ -1,0 +1,138 @@
+use core::panic;
+use std::collections::HashSet;
+use std::process::{Command, ExitStatus};
+
+use anyhow::{Context, Result};
+use regex::Regex;
+
+use crate::backend::backend_trait::{Backend, Switches, Text};
+use crate::backend::macros::impl_backend_constants;
+use crate::{Group, Package};
+
+#[derive(Debug, Clone)]
+pub struct Fedora {
+    pub(crate) packages: HashSet<Package>,
+}
+
+const BINARY: Text = "dnf";
+const SECTION: Text = "fedora";
+
+const SWITCHES_INFO: Switches = &["list", "--installed"];
+const SWITCHES_INSTALL: Switches = &["install"];
+const SWITCHES_MAKE_DEPENDENCY: Switches = &[];
+const SWITCHES_NOCONFIRM: Switches = &["--assumeyes"];
+const SWITCHES_REMOVE: Switches = &["remove"];
+
+const SUPPORTS_AS_DEPENDENCY: bool = true;
+
+impl Backend for Fedora {
+    impl_backend_constants!();
+
+    fn get_all_installed_packages(&self) -> Result<HashSet<Package>> {
+        let re_str = r"^[0-9A-Za-z_-]*.";
+        let re = Regex::new(re_str)?;
+
+        let mut cmd = Command::new(self.get_binary());
+        cmd.args(self.get_switches_info());
+        let output = String::from_utf8(cmd.output()?.stdout)?;
+
+        let packages: HashSet<Package> = output
+            .lines()
+            .map(|line| {
+                let result = re
+                    .find(
+                        line.split_whitespace()
+                            .next()
+                            .expect("First word cannot be empty!"),
+                    )
+                    .expect("Not a valid package name!");
+                let mut result = result.as_str().to_string();
+                result.pop();
+                result.into()
+            })
+            .collect();
+        Ok(packages)
+    }
+
+    fn get_explicitly_installed_packages(&self) -> Result<HashSet<Package>> {
+        let re_str = r"^(([A-Za-z_]*[0-9]*)-)*";
+        let re = Regex::new(re_str)?;
+
+        let mut cmd = Command::new(self.get_binary());
+        cmd.args(&["history", "userinstalled"]);
+        let output = String::from_utf8(cmd.output()?.stdout)?;
+
+        let packages: HashSet<Package> = output
+            .lines()
+            .skip(1)
+            .map(|line| {
+                let word = re.find(line).expect("Not a valid package name");
+                let mut word = word.as_str().to_string();
+                word.pop();
+                let pack = word.rsplit_once('-').map_or(word.clone(), |(pack, term)| {
+                    let mut value = true;
+                    for i in term.chars() {
+                        if !i.is_numeric() {
+                            value = false;
+                            break;
+                        }
+                    }
+                    if !value {
+                        pack.to_string() + "-" + term
+                    } else {
+                        pack.to_string()
+                    }
+                });
+                pack.into()
+            })
+            .collect();
+        Ok(packages)
+    }
+
+    /// Install the specified packages.
+    fn install_packages(&self, packages: &[Package], noconfirm: bool) -> Result<ExitStatus> {
+        let mut cmd = Command::new("sudo");
+        cmd.arg(self.get_binary());
+        cmd.args(self.get_switches_install());
+
+        if noconfirm {
+            cmd.args(self.get_switches_noconfirm());
+        }
+
+        for p in packages {
+            cmd.arg(format!("{p}"));
+        }
+
+        cmd.status()
+            .with_context(|| format!("running command {cmd:?}"))
+    }
+
+    fn remove_packages(&self, packages: &[Package], noconfirm: bool) -> Result<ExitStatus> {
+        let mut cmd = Command::new("sudo");
+        cmd.arg(self.get_binary());
+        cmd.args(self.get_switches_remove());
+
+        if noconfirm {
+            cmd.args(self.get_switches_noconfirm());
+        }
+
+        for p in packages {
+            cmd.arg(format!("{p}"));
+        }
+
+        cmd.status()
+            .with_context(|| format!("running command [{cmd:?}]"))
+    }
+
+    fn make_dependency(&self, _: &[Package]) -> Result<ExitStatus> {
+        panic!("Not supported by the package manager!")
+    }
+}
+
+impl Fedora {
+    pub fn new() -> Self {
+        Fedora {
+            packages: HashSet::new(),
+        }
+    }
+}

--- a/crates/pacdef_core/src/backend/actual/mod.rs
+++ b/crates/pacdef_core/src/backend/actual/mod.rs
@@ -2,7 +2,6 @@
 pub mod arch;
 #[cfg(feature = "debian")]
 pub mod debian;
-#[cfg(feature = "fedora")]
 pub mod fedora;
 pub mod flatpak;
 pub mod python;

--- a/crates/pacdef_core/src/backend/actual/mod.rs
+++ b/crates/pacdef_core/src/backend/actual/mod.rs
@@ -2,6 +2,8 @@
 pub mod arch;
 #[cfg(feature = "debian")]
 pub mod debian;
+#[cfg(feature = "fedora")]
+pub mod fedora;
 pub mod flatpak;
 pub mod python;
 pub mod rust;

--- a/crates/pacdef_core/src/backend/mod.rs
+++ b/crates/pacdef_core/src/backend/mod.rs
@@ -18,7 +18,6 @@ pub enum Backends {
     #[cfg(feature = "debian")]
     Debian,
     Flatpak,
-    #[cfg(feature = "fedora")]
     Fedora,
     Python,
     Rust,

--- a/crates/pacdef_core/src/backend/mod.rs
+++ b/crates/pacdef_core/src/backend/mod.rs
@@ -18,6 +18,8 @@ pub enum Backends {
     #[cfg(feature = "debian")]
     Debian,
     Flatpak,
+    #[cfg(feature = "fedora")]
+    Fedora,
     Python,
     Rust,
     Rustup,


### PR DESCRIPTION
This adds fedora as a backend using the dnf package manager. Closes #54.
