### PR TITLE
Add 'apply' option to review

### DIFF
--- a/crates/pacdef_core/src/review/datastructures.rs
+++ b/crates/pacdef_core/src/review/datastructures.rs
@@ -21,6 +21,7 @@ pub(super) enum ReviewIntention {
     Invalid,
     Skip,
     Quit,
+    Apply,
 }
 
 #[derive(Debug)]
@@ -88,6 +89,7 @@ impl IntoIterator for ReviewsPerBackend {
 pub(super) enum ContinueWithReview {
     Yes,
     No,
+    NoAndApply,
 }
 
 fn extract_actions(

--- a/crates/pacdef_core/src/review/mod.rs
+++ b/crates/pacdef_core/src/review/mod.rs
@@ -34,6 +34,7 @@ pub fn review(
             match get_action_for_package(package, &groups, &mut actions, &*backend)? {
                 ContinueWithReview::Yes => continue,
                 ContinueWithReview::No => return Ok(()),
+                ContinueWithReview::NoAndApply => break,
             }
         }
         reviews.push((backend, actions));
@@ -101,6 +102,7 @@ fn get_action_for_package(
             ReviewIntention::Invalid => (),
             ReviewIntention::Skip => break,
             ReviewIntention::Quit => return Ok(ContinueWithReview::No),
+            ReviewIntention::Apply => return Ok(ContinueWithReview::NoAndApply),
         }
     }
     Ok(ContinueWithReview::Yes)
@@ -122,6 +124,7 @@ fn ask_user_action_for_package(supports_as_dependency: bool) -> Result<ReviewInt
         'i' => Ok(ReviewIntention::Info),
         'q' => Ok(ReviewIntention::Quit),
         's' => Ok(ReviewIntention::Skip),
+        'p' => Ok(ReviewIntention::Apply),
         _ => Ok(ReviewIntention::Invalid),
     }
 }
@@ -140,7 +143,7 @@ fn print_query(supports_as_dependency: bool) -> Result<()> {
         query.push_str("(a)s dependency, ");
     }
 
-    query.push_str("(q)uit? ");
+    query.push_str("a(p)ply, (q)uit? ");
 
     print!("{query}");
     stdout().lock().flush()?;


### PR DESCRIPTION
This adds another option to the review process allowing the user to exit the review and apply the decisions made so far.

I'm just starting to use pacdef and I have a few hundred packages to review. I've had to start over multiple times due to pacman/aur errors or accidents. This would essentially allow the user to save a "checkpoint" during the review process.

Another option would be to update the group file immediately when adding a package to a group or assigning it as a dependency. Then if the user is interrupted for whatever reason, he can pick up where he left off even if he doesn't apply. If you'd like, I can look into adding this feature as well.

Furthermore, a better approach might also be a temp file which records the decision for each package and then applies the changes at the end. This would also allow for resuming the review process but save all changes until the end. This is a bit more involved but if you're interested, I can look into adding this as well.

Thanks for the cool app. I just tried out NixOS for about a week and am coming back to Arch. I like many of the declarative features of NixOS and would like to see more of that in the Arch ecosystem.

Implements part of #36 