### PR TITLE
Release action to build binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
       image: ghcr.io/archlinux/archlinux:base-devel
     strategy:
       matrix:
-        features: [arch, debian]
+        features: [default, arch, debian]
     steps:
-    - name: Install rust toolchain
-      run: pacman -Syy --noconfirm rust
+    - name: Install dependencies
+      run: pacman -Syy --noconfirm rust apt
     - uses: actions/checkout@master
     - name: Build
       run: cargo build --release --features ${{ matrix.features }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,16 @@ on:
 jobs:
   release:
     name: release
-    runs-on: ubuntu-latest
+    runs-on: archlinux-latest
+    strategy:
+      matrix:
+        features: [arch, debian]        
     steps:
     - uses: actions/checkout@master
     - name: Compile and release
       uses: rust-build/rust-build.action@v1.4.5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
         RUSTTARGET: x86_64-unknown-linux-musl
+        FEATURES: ${{ features }}
         EXTRA_FILES: "README.md LICENSE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,6 @@ jobs:
     - name: Create archive
       run: tar czf pacdef-${{ matrix.features }}.tar.gz target/release/pacdef LICENSE README.md
     - name: Upload to release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
           files: pacdef-${{ matrix.features }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         features: [arch, debian]
     steps:
     - name: Install rust toolchain
-      run: pacman -Syy --noconfirm rust libalpm
+      run: pacman -Syy --noconfirm rust
     - uses: actions/checkout@master
     - name: Build
       run: cargo build --release --features ${{ matrix.features }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,20 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/archlinux/archlinux:latest
     strategy:
       matrix:
-        features: [arch, debian]        
+        features: [arch, debian]
     steps:
+    - name: Install rust toolchain
+      run: pacman -Syy --noconfirm rust
     - uses: actions/checkout@master
-    - name: Compile and release
-      uses: rust-build/rust-build.action@v1.4.5
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        RUSTTARGET: x86_64-unknown-linux-musl
-        FEATURES: ${{ matrix.features }}
-        EXTRA_FILES: "README.md LICENSE"
+    - name: Build
+      run: cargo build --release --features ${{ matrix.features }}
+    - name: Create archive
+      run: tar czf pacdef-${{ matrix.features }}.tar.gz target/release/pacdef LICENCE README.md
+    - name: Upload to release
+      uses: softprops/action-gh-release@v1
+      with:
+          files: pacdef-pacdef-${{ matrix.features }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build
       run: cargo build --release --features ${{ matrix.features }}
     - name: Create archive
-      run: tar czf pacdef-${{ matrix.features }}.tar.gz target/release/pacdef LICENCE README.md
+      run: tar czf pacdef-${{ matrix.features }}.tar.gz target/release/pacdef LICENSE README.md
     - name: Upload to release
       uses: softprops/action-gh-release@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,5 +18,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RUSTTARGET: x86_64-unknown-linux-musl
-        FEATURES: ${{ features }}
+        FEATURES: ${{ matrix.features }}
         EXTRA_FILES: "README.md LICENSE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         features: [default, arch, debian]
     steps:
     - name: Install dependencies
-      run: pacman -Syy --noconfirm rust apt
+      run: pacman -Syy --noconfirm rust apt git
     - uses: actions/checkout@master
     - name: Build
       run: cargo build --release --features ${{ matrix.features }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,12 @@ jobs:
     - uses: actions/checkout@master
     - name: Build
       run: cargo build --release --features ${{ matrix.features }}
-    - name: Create archive
-      run: tar czf pacdef-${{ matrix.features }}.tar.gz target/release/pacdef LICENSE README.md
+    - name: Create temporary directory
+      run: mkdir pacdef-${{ matrix.features }}
+    - name: Copy artifacts to directory
+      run: cp -R target/release/pacdef man LICENSE README.md pacdef-${{ matrix.features }}
+    - name: Create archive from directory
+      run: tar czf pacdef-${{ matrix.features }}.tar.gz pacdef-${{ matrix.features }}
     - name: Upload to release
       uses: softprops/action-gh-release@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,13 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/archlinux/archlinux:latest
+      image: ghcr.io/archlinux/archlinux:base-devel
     strategy:
       matrix:
         features: [arch, debian]
     steps:
     - name: Install rust toolchain
-      run: pacman -Syy --noconfirm rust
+      run: pacman -Syy --noconfirm rust libalpm
     - uses: actions/checkout@master
     - name: Build
       run: cargo build --release --features ${{ matrix.features }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     name: release
-    runs-on: archlinux-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         features: [arch, debian]        

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,4 @@ jobs:
     - name: Upload to release
       uses: softprops/action-gh-release@v1
       with:
-          files: pacdef-pacdef-${{ matrix.features }}.tar.gz
+          files: pacdef-${{ matrix.features }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Compile and release
+      uses: rust-build/rust-build.action@v1.4.5
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+        RUSTTARGET: x86_64-unknown-linux-musl
+        EXTRA_FILES: "README.md LICENSE"


### PR DESCRIPTION
Action will build binary on release and attach the resulting zip to the release.

[Example release](https://github.com/thechubbypanda/pacdef/releases/tag/0.0.1-alpha)

[Related Actions run](https://github.com/thechubbypanda/pacdef/actions/runs/8434849647)

Part of #58 