### PR TITLE
Warnings and Error refactors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,42 +229,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,29 +243,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "itoa"
@@ -357,11 +298,9 @@ dependencies = [
  "clap",
  "const_format",
  "enum_dispatch",
- "env_logger 0.11.3",
  "libc",
  "log",
  "path-absolutize",
- "pretty_env_logger",
  "regex",
  "rust-apt",
  "serde",
@@ -394,16 +333,6 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "pretty_env_logger"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
-dependencies = [
- "env_logger 0.10.2",
- "log",
-]
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +279,29 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "itoa"
@@ -272,6 +331,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
+name = "log"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,8 +357,11 @@ dependencies = [
  "clap",
  "const_format",
  "enum_dispatch",
+ "env_logger 0.11.3",
  "libc",
+ "log",
  "path-absolutize",
+ "pretty_env_logger",
  "regex",
  "rust-apt",
  "serde",
@@ -326,6 +394,16 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "pretty_env_logger"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
+dependencies = [
+ "env_logger 0.10.2",
+ "log",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/crates/pacdef/Cargo.toml
+++ b/crates/pacdef/Cargo.toml
@@ -20,6 +20,9 @@ termios = "0.3"
 walkdir = "2.5"
 libc = "0.2"
 enum_dispatch = "0.3"
+log = "0.4"
+pretty_env_logger = "0.5"
+env_logger = "0.11"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/pacdef/Cargo.toml
+++ b/crates/pacdef/Cargo.toml
@@ -20,9 +20,7 @@ termios = "0.3"
 walkdir = "2.5"
 libc = "0.2"
 enum_dispatch = "0.3"
-log = "0.4"
-pretty_env_logger = "0.5"
-env_logger = "0.11"
+log = { version = "0.4", features = ["std"] }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/pacdef/src/backend/actual/rust.rs
+++ b/crates/pacdef/src/backend/actual/rust.rs
@@ -47,9 +47,7 @@ impl Backend for Rust {
         let content = match read_to_string(file) {
             Ok(string) => string,
             Err(err) if err.kind() == NotFound => {
-                eprintln!(
-                    "WARNING: no crates file found for cargo. Assuming no crates installed yet."
-                );
+                log::warn!("no crates file found for cargo. Assuming no crates installed yet.");
                 return Ok(HashSet::new());
             }
             Err(err) => bail!(err),

--- a/crates/pacdef/src/errors.rs
+++ b/crates/pacdef/src/errors.rs
@@ -1,5 +1,5 @@
 use std::error::Error as ErrorTrait;
-use std::fmt::{Display, Write};
+use std::fmt::Display;
 use std::path::PathBuf;
 
 /// Error types for pacdef.
@@ -23,26 +23,19 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::NoPackagesFound => f.write_str("no packages matching query"),
-            Self::ConfigFileNotFound => f.write_str("config file not found"),
-            Self::GroupFileNotFound(name) => f.write_str(&format!("group file '{name}' not found")),
-            Self::GroupAlreadyExists(path) => f.write_str(&format!(
-                "group file '{}' already exists",
-                path.to_string_lossy()
-            )),
-            Self::InvalidGroupName(name) => {
-                f.write_str(&format!("group name '{name}' is not valid"))
+            Self::NoPackagesFound => write!(f, "no packages matching query"),
+            Self::ConfigFileNotFound => write!(f, "config file not found"),
+            Self::GroupFileNotFound(name) => write!(f, "group file '{name}' not found"),
+            Self::GroupAlreadyExists(path) => {
+                write!(f, "group file '{}' already exists", path.to_string_lossy())
             }
+            Self::InvalidGroupName(name) => write!(f, "group name '{name}' is not valid"),
             Self::MultipleGroupsNotFound(vec) => {
-                f.write_str("could not find the following groups:\n")?;
-                let mut iter = vec.iter().peekable();
-                while let Some(group) = iter.next() {
-                    f.write_str(&format!("  {group}"))?;
-                    if iter.peek().is_some() {
-                        f.write_char('\n')?;
-                    }
-                }
-                Ok(())
+                write!(
+                    f,
+                    "could not find the following groups: [{}]",
+                    vec.join(", ")
+                )
             }
         }
     }

--- a/crates/pacdef/src/grouping/group.rs
+++ b/crates/pacdef/src/grouping/group.rs
@@ -153,13 +153,13 @@ impl Group {
                 }
                 Err(e) => {
                     let err = e.root_cause();
-                    eprintln!("WARNING: could not process a section under group '{name}': {err}");
+                    log::warn!("could not process a section under group '{name}': {err}");
                 }
             }
         }
 
         if sections.is_empty() {
-            eprintln!("WARNING: no sections found in group '{name}'");
+            log::warn!("no sections found in group '{name}'");
         }
 
         let path = path.into();

--- a/crates/pacdef/src/grouping/section.rs
+++ b/crates/pacdef/src/grouping/section.rs
@@ -41,7 +41,7 @@ fn insert_package(package: Package, packages: &mut HashSet<Package>) {
     let newly_inserted = packages.insert(package);
 
     if !newly_inserted {
-        eprintln!("warning: {package_name} occurs twice in the same section");
+        log::warn!("{package_name} occurs twice in the same section");
     }
 }
 

--- a/crates/pacdef/src/main.rs
+++ b/crates/pacdef/src/main.rs
@@ -31,10 +31,26 @@ Check out https://github.com/steven-omaha/pacdef/blob/main/README.md#configurati
 This message will not appear again.
 ------";
 
+struct PacdefLogger;
+
+impl log::Log for PacdefLogger {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        if self.enabled(record.metadata()) {
+            eprintln!("{} - {}", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
 fn main() -> ExitCode {
-    pretty_env_logger::formatted_builder()
-        .filter_level(log::LevelFilter::Info)
-        .init();
+    log::set_boxed_logger(Box::new(PacdefLogger))
+        .map(|()| log::set_max_level(log::LevelFilter::Info))
+        .expect("no other loggers should have been set");
 
     handle_final_result(main_inner())
 }

--- a/crates/pacdef/src/main.rs
+++ b/crates/pacdef/src/main.rs
@@ -32,6 +32,10 @@ This message will not appear again.
 ------";
 
 fn main() -> ExitCode {
+    pretty_env_logger::formatted_builder()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+
     handle_final_result(main_inner())
 }
 
@@ -43,7 +47,7 @@ fn handle_final_result(result: Result<()>) -> ExitCode {
         Ok(_) => ExitCode::SUCCESS,
         Err(ref e) => {
             if let Some(root_error) = e.root_cause().downcast_ref::<PacdefError>() {
-                eprintln!("{root_error}");
+                log::error!("{root_error}");
                 ExitCode::FAILURE
             } else {
                 result.report()
@@ -75,10 +79,14 @@ fn main_inner() -> Result<()> {
     let groups = Group::load(&group_dir, config.warn_not_symlinks)
         .with_context(|| format!("loading groups under {}", group_dir.to_string_lossy()))?;
 
+    if groups.is_empty() {
+        log::warn!("no group files found");
+    }
+
     for group in groups.iter() {
         if group.warn_symlink {
-            eprintln!(
-                "WARNING: group file {} is not a symlink",
+            log::warn!(
+                "group file {} is not a symlink",
                 group.path.to_string_lossy()
             );
         }

--- a/crates/pacdef/src/search.rs
+++ b/crates/pacdef/src/search.rs
@@ -20,7 +20,6 @@ use crate::{
 /// - no matching packages could be found.
 pub fn search_packages(regex_str: &str, groups: &Groups) -> Result<()> {
     if groups.is_empty() {
-        eprintln!("WARNING: no group files found");
         bail!(crate::errors::Error::NoPackagesFound);
     }
 


### PR DESCRIPTION
Apologies for yet another PR, this one is much smaller this time. It's based off of #74 so #74 will need to be merged before this can be.

I've switched all the `eprintln` calls to use the `log` crate with the `pretty_env_logger` as a log consumer which makes the code easier to read and also adds a splash of color to the error messages.

I also refactored the `impl Display for Error` to use the `write!()` macro which simplifies things a lot.