### PR TITLE
build: Update build script

### DIFF
--- a/crates/pacdef/build.rs
+++ b/crates/pacdef/build.rs
@@ -9,5 +9,5 @@ fn main() {
         _ => String::new(),
     };
 
-    println!("cargo:rustc-env=GIT_HASH={git_hash}");
+    println!("cargo::rustc-env=GIT_HASH={git_hash}");
 }


### PR DESCRIPTION
cargo version 1.77 onwards added support for `cargo::` to communicate with
cargo and deprecated the old `cargo:` syntax.