### PR TITLE
fix(rustup): Account for version dates

### DIFF
--- a/crates/pacdef/src/backend/actual/rustup/mod.rs
+++ b/crates/pacdef/src/backend/actual/rustup/mod.rs
@@ -124,7 +124,7 @@ impl Rustup {
         let mut val = Vec::new();
 
         for line in output.lines() {
-            let toolchain = line.split('-').next();
+            let toolchain = line.rsplitn(5, '-').last();
             match toolchain {
                 Some(name) => val.push(name.to_string()),
                 None => bail!("Toolchain name not provided!"),

--- a/crates/pacdef/src/core.rs
+++ b/crates/pacdef/src/core.rs
@@ -548,11 +548,7 @@ pub const fn get_version_string() -> &'static str {
     const VERSION: &str = env!("CARGO_PKG_VERSION");
     const HASH: &str = env!("GIT_HASH");
 
-    if HASH.is_empty() {
-        VERSION
-    } else {
-        formatcp!("{VERSION} ({HASH})")
-    }
+    formatcp!("{VERSION} ({HASH})")
 }
 
 /// Get a vector with the names of all backends, sorted alphabetically.


### PR DESCRIPTION
The previous implementation skipped the date of
the release in case the nightly was not the latest
one. This commit relies on the fact that the
rustup toolchains have a target triple at the end
of the toolchain name when listed and is prone to
break/error should that not be true for all
toolchains. This covers, in particular, symlinks
for any custom toolchains.