### PR TITLE
Fix libalpm not found #90

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "alpm"
-version = "3.0.5"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310ec5dc25b236ee96bebf975af2d2de85e61001a7c39a0a7436a414ff3f6490"
+checksum = "c02d4b4d6bc861451437cdbd7feb35385874ff4cc449ace8e793fe8c30533240"
 dependencies = [
  "alpm-sys",
  "bitflags",
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "alpm-sys"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a17e0cf15a06d4b86e30c606ee8808ad791300f3bd5e364c30360354b010bd"
+checksum = "ad5eb56a41bf4f036c600aa1ddff354971926dd8ea29a3fb6589c6c375bf918b"
 dependencies = [
  "pkg-config",
 ]

--- a/crates/pacdef/Cargo.toml
+++ b/crates/pacdef/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1.0"
 toml = "0.4"
 
 # backends
-alpm = { version = "3.0", optional = true }
+alpm = { version = "4.0.1", optional = true }
 rust-apt = { version = "0.7", optional = true }
 
 [features]


### PR DESCRIPTION
Trying to fix  https://github.com/steven-omaha/pacdef/issues/90
Bump version of alpm to v4.0.1. It seems to build fine on my arch machine, not sure what would happen on Debian based distros