### PR TITLE
feat: Add Snap package manager backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Pull requests for additional backends are welcome!
 | Python       | `pip`           | `[python]`  | built-in     |                                                                                          |
 | Rust         | `cargo`         | `[rust]`    | built-in     |                                                                                          |
 | Rustup       | `rustup`        | `[rustup]`  | built-in     | See the comments [below](#rustup) about the syntax of the packages in the group file.    |
+| Snap         | `snap`          | `[snap]`    | built-in     | Manages all packages as explicit - no auto/manual distinction like in apt                |
 | Void Linux   | `xbps`          | `[void]`    | built-in     |                                                                                          |
 
 Backends that have a `feature flag` require setting the respective flag for the build process.
@@ -110,6 +111,16 @@ Any backend can be disabled during runtime (see below, "[Configuration](#configu
 For example, to build `pacdef` with support for Debian Linux, you can run one of the two commands.
 * (recommended) `cargo install -F debian pacdef`, this downloads and builds it from [https://crates.io](https://crates.io)
 * in a clone of this repository, `cargo install --path . -F debian`
+
+### Snap Implementation Details
+
+Unlike package managers like `apt` which have a concept of manually installed vs automatically installed dependencies, Snap treats all packages the same way. There is no distinction between manually installed packages and dependencies.
+
+In pacdef, this means:
+- All installed Snap packages are considered "explicitly installed"
+- A Snap package is considered "unmanaged" if it's installed but not listed in any group file
+- When running `pacdef package clean`, any Snap package not listed in your group files will be considered for removal
+- The `make_dependency` operation is not supported for Snap packages
 
 ### Example
 
@@ -150,13 +161,13 @@ Usage on different machines:
 ## Commands
 
 | Subcommand                        | Description                                                           |
-|-----------------------------------|-----------------------------------------------------------------------|
-| `group import [<path>...]`        | create a symlink to the specified group file(s) in your groups folder | 
-| `group export [args] <group> ...` | export (move) a non-symlink group and re-import it as symlink         | 
-| `group list`                      | list names of all groups                                              |  
-| `group new [-e] [<group>...]`     | create new groups, use `-e` to edit them immediately after creation   | 
+| --------------------------------- | --------------------------------------------------------------------- |
+| `group import [<path>...]`        | create a symlink to the specified group file(s) in your groups folder |
+| `group export [args] <group> ...` | export (move) a non-symlink group and re-import it as symlink         |
+| `group list`                      | list names of all groups                                              |
+| `group new [-e] [<group>...]`     | create new groups, use `-e` to edit them immediately after creation   |
 | `group remove [<group>...]`       | remove a previously imported group                                    |
-| `group show [<group>...]`         | show contents of a group                                              |  
+| `group show [<group>...]`         | show contents of a group                                              |
 | `package clean [--noconfirm]`     | remove all unmanaged packages                                         |
 | `package review`                  | for each unmanaged package interactively decide what to do            |
 | `package search <regex>`          | search for managed packages that match the search string              |

--- a/crates/pacdef/src/backend/actual/mod.rs
+++ b/crates/pacdef/src/backend/actual/mod.rs
@@ -7,4 +7,5 @@ pub mod flatpak;
 pub mod python;
 pub mod rust;
 pub mod rustup;
+pub mod snap;
 pub mod void;

--- a/crates/pacdef/src/backend/actual/snap.rs
+++ b/crates/pacdef/src/backend/actual/snap.rs
@@ -1,0 +1,98 @@
+use anyhow::Result;
+use std::process::Command;
+
+use crate::backend::root::build_base_command_with_privileges;
+use crate::cmd::run_external_command;
+use crate::prelude::*;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Snap {}
+
+impl Snap {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for Snap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Backend for Snap {
+    fn backend_info(&self) -> BackendInfo {
+        BackendInfo {
+            binary: "snap".to_string(),
+            section: "snap",
+            switches_info: &["info"],
+            switches_install: &["install"],
+            switches_noconfirm: &["--assume-yes"],
+            switches_remove: &["remove"],
+            switches_make_dependency: None, // Snap doesn't have the concept of dependencies
+        }
+    }
+
+    fn get_all_installed_packages(&self) -> Result<Packages> {
+        let mut cmd = Command::new(self.backend_info().binary);
+        cmd.args(["list"]);
+
+        let output = String::from_utf8(cmd.output()?.stdout)?;
+        let mut packages = Packages::new();
+
+        // Skip the first line which is the header
+        for line in output.lines().skip(1) {
+            // Format is: name  version  rev   tracking  publisher  notes
+            if let Some(name) = line.split_whitespace().next() {
+                packages.insert(Package::from(name.to_string()));
+            }
+        }
+
+        Ok(packages)
+    }
+
+    fn get_explicitly_installed_packages(&self) -> Result<Packages> {
+        // Snap doesn't differentiate between explicitly and implicitly installed packages
+        // so we return all installed packages
+        self.get_all_installed_packages()
+    }
+
+    fn make_dependency(&self, _packages: &Packages) -> Result<()> {
+        // Snap doesn't have the concept of package dependencies in the same way as other package managers
+        panic!("not supported by {}", self.backend_info().binary)
+    }
+
+    fn install_packages(&self, packages: &Packages, noconfirm: bool) -> Result<()> {
+        let backend_info = self.backend_info();
+        let mut cmd = build_base_command_with_privileges(&backend_info.binary);
+
+        cmd.args(backend_info.switches_install);
+
+        if noconfirm {
+            cmd.args(backend_info.switches_noconfirm);
+        }
+
+        for p in packages {
+            cmd.arg(format!("{p}"));
+        }
+
+        run_external_command(cmd)
+    }
+
+    fn remove_packages(&self, packages: &Packages, noconfirm: bool) -> Result<()> {
+        let backend_info = self.backend_info();
+        let mut cmd = build_base_command_with_privileges(&backend_info.binary);
+
+        cmd.args(backend_info.switches_remove);
+
+        if noconfirm {
+            cmd.args(backend_info.switches_noconfirm);
+        }
+
+        for p in packages {
+            cmd.arg(format!("{p}"));
+        }
+
+        run_external_command(cmd)
+    }
+}

--- a/crates/pacdef/src/backend/actual/snap.rs
+++ b/crates/pacdef/src/backend/actual/snap.rs
@@ -27,7 +27,7 @@ impl Backend for Snap {
             section: "snap",
             switches_info: &["info"],
             switches_install: &["install"],
-            switches_noconfirm: &["--assume-yes"],
+            switches_noconfirm: &[],
             switches_remove: &["remove"],
             switches_make_dependency: None, // Snap doesn't have the concept of dependencies
         }
@@ -62,15 +62,11 @@ impl Backend for Snap {
         panic!("not supported by {}", self.backend_info().binary)
     }
 
-    fn install_packages(&self, packages: &Packages, noconfirm: bool) -> Result<()> {
+    fn install_packages(&self, packages: &Packages, _noconfirm: bool) -> Result<()> {
         let backend_info = self.backend_info();
         let mut cmd = build_base_command_with_privileges(&backend_info.binary);
 
         cmd.args(backend_info.switches_install);
-
-        if noconfirm {
-            cmd.args(backend_info.switches_noconfirm);
-        }
 
         for p in packages {
             cmd.arg(format!("{p}"));
@@ -79,15 +75,11 @@ impl Backend for Snap {
         run_external_command(cmd)
     }
 
-    fn remove_packages(&self, packages: &Packages, noconfirm: bool) -> Result<()> {
+    fn remove_packages(&self, packages: &Packages, _noconfirm: bool) -> Result<()> {
         let backend_info = self.backend_info();
         let mut cmd = build_base_command_with_privileges(&backend_info.binary);
 
         cmd.args(backend_info.switches_remove);
-
-        if noconfirm {
-            cmd.args(backend_info.switches_noconfirm);
-        }
 
         for p in packages {
             cmd.arg(format!("{p}"));

--- a/crates/pacdef/src/backend/mod.rs
+++ b/crates/pacdef/src/backend/mod.rs
@@ -62,6 +62,7 @@ pub enum AnyBackend {
     Python(Python),
     Rust(Rust),
     Rustup(Rustup),
+    Snap(Snap),
     Void(Void),
 }
 impl AnyBackend {
@@ -77,6 +78,7 @@ impl AnyBackend {
             Self::Python(Python::new(config)),
             Self::Rust(Rust::new()),
             Self::Rustup(Rustup::new()),
+            Self::Snap(Snap::new()),
             Self::Void(Void::new()),
         ]
         .into_iter()
@@ -93,6 +95,7 @@ impl AnyBackend {
             "python" => Ok(Self::Python(Python::new(config))),
             "rust" => Ok(Self::Rust(Rust::new())),
             "rustup" => Ok(Self::Rustup(Rustup::new())),
+            "snap" => Ok(Self::Snap(Snap::new())),
             "void" => Ok(Self::Void(Void::new())),
             _ => Err(anyhow::anyhow!(
                 "no matching backend for the section: {section}"

--- a/crates/pacdef/src/core.rs
+++ b/crates/pacdef/src/core.rs
@@ -548,6 +548,7 @@ pub const fn get_version_string() -> &'static str {
     const VERSION: &str = env!("CARGO_PKG_VERSION");
     const HASH: &str = env!("GIT_HASH");
 
+    #[allow(clippy::const_is_empty)]
     if HASH.is_empty() {
         VERSION
     } else {

--- a/crates/pacdef/src/prelude.rs
+++ b/crates/pacdef/src/prelude.rs
@@ -3,7 +3,8 @@ pub use crate::backend::actual::arch::Arch;
 #[cfg(feature = "debian")]
 pub use crate::backend::actual::debian::Debian;
 pub use crate::backend::actual::{
-    fedora::Fedora, flatpak::Flatpak, python::Python, rust::Rust, rustup::Rustup, void::Void,
+    fedora::Fedora, flatpak::Flatpak, python::Python, rust::Rust, rustup::Rustup, snap::Snap,
+    void::Void,
 };
 pub use crate::backend::backend_trait::{Backend, BackendInfo, Switches, Text};
 pub use crate::backend::todo_per_backend::ToDoPerBackend;


### PR DESCRIPTION
This PR adds support for the Snap package manager to pacdef.

### Changes

- Add Snap backend implementation for basic package management
- Document Snap implementation details in README
- Add Snap to supported backends table
- Fix clippy warning in get_version_string()

### Implementation Details

The Snap backend provides basic package management functionality while respecting Snap's unique characteristics:
- No distinction between auto/manual packages (unlike apt)
- All packages treated as explicitly installed
- No dependency management support

### Documentation

- Added Snap to the supported backends table
- Added detailed documentation about how pacdef handles Snap packages
- Explained differences between Snap and other package managers (particularly apt)

### Testing

Tested basic operations:
- Package installation
- Package removal
- Package listing
- Unmanaged package detection

Closes #94 